### PR TITLE
skip ov

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ After loading all the provided data on first boot the device is still not in
     2. The TLS connection **MUST** be secured on the client-side with the IDevId of the active control card.
     3. The responses from the bootz-server are signed by ownership-certificate. The device validates the ownership-voucher, which authenticates the ownership-certificate. The device verifies the signature of the message body before accepting the message.
     4. If the signature could not be verified, the bootstrap process starts from Step 1.
+
+Note: though a device SHOULD validate ownership by default, in some environment (e.g. a lab) we might not want to do so. In this case, the device can be explicitly configured to skip the ownership validation, and the device will then not set the `nonce` field in the `GetBootstrapDataRequest message`. The bootstrap server may proceed without signing the response and without providing the ownership voucher and ownership certificate.
+
 3. Ownership Voucher and Ownership Certificate
     1. These artifacts have the same meaning as the original sZTP [RFC](https://www.rfc-editor.org/rfc/rfc8572#section-3.2). This document uses OC and PDC interchangeably for convenience. However, we should keep in mind that OV authenticates a PDC (Pinned Domain Cert), and OC might be a distinct certificate with a chain of trust to the PDC.
     2. The contents of the GetBootstrappingDataResponse has an inner message body. The outer message contains the Ownership Voucher, the Ownership Certificate and a signature over the inner message body. The signature is generated using the OC and the nonce.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ After loading all the provided data on first boot the device is still not in
     3. The responses from the bootz-server are signed by ownership-certificate. The device validates the ownership-voucher, which authenticates the ownership-certificate. The device verifies the signature of the message body before accepting the message.
     4. If the signature could not be verified, the bootstrap process starts from Step 1.
 
-Note: though a device SHOULD validate ownership by default, in some environment (e.g. a lab) we might not want to do so. In this case, the device can be explicitly configured to skip the ownership validation, and the device will then not set the `nonce` field in the `GetBootstrapDataRequest message`. The bootstrap server may proceed without signing the response and without providing the ownership voucher and ownership certificate.
+Note: though a device SHOULD validate ownership by default, in some environment (e.g. a lab) we might not want to do so.
+In this case, the device can be explicitly configured to skip the ownership validation, and the device will then not set the `nonce` field in the `GetBootstrapDataRequest message`.
+The bootstrap server may proceed without signing the response and without providing the ownership voucher and ownership certificate.
 
 3. Ownership Voucher and Ownership Certificate
     1. These artifacts have the same meaning as the original sZTP [RFC](https://www.rfc-editor.org/rfc/rfc8572#section-3.2). This document uses OC and PDC interchangeably for convenience. However, we should keep in mind that OV authenticates a PDC (Pinned Domain Cert), and OC might be a distinct certificate with a chain of trust to the PDC.

--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -50,6 +50,8 @@ message GetBootstrapDataRequest {
   ChassisDescriptor chassis_descriptor = 1;
   ControlCardState control_card_state = 2;
   // A nonce that the bootstrap server should use when signing the response.
+  // Not settting this field indicates that the device is configured not to
+  // check for ownership voucher.
   string nonce = 1001;
 }
 
@@ -131,15 +133,27 @@ message GetBootstrapDataResponse {
   // the nonce is added to verify the contents from the client.
   message BootstrapDataSigned {
     repeated BootstrapDataResponse responses = 1;
+    // This should not be set if the device does not check for ownership
+    // voucher, which is indicated by the device not setting the nonce field
+    // in the GetBootstrapDataRequest message.
     string nonce = 2;
   }
   
   BootstrapDataSigned signed_response = 1;
+  // This should not be set if the device does not check for ownership
+  // voucher, which is indicated by the device not setting the nonce field
+  // in the GetBootstrapDataRequest message.
   bytes ownership_voucher = 101;
+  // This should not be set if the device does not check for ownership
+  // voucher, which is indicated by the device not setting the nonce field
+  // in the GetBootstrapDataRequest message.
   bytes ownership_certificate = 102;
   // This is a signature generated over the bytes of the signed_response field,
   // using the ownership_certificate.
-  string response_signature = 103;
+  // This should not be set if the device does not check for ownership
+  // voucher, which is indicated by the device not setting the nonce field
+  // in the GetBootstrapDataRequest message.
+    string response_signature = 103;
 }
 
 message SoftwareImage {

--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -153,7 +153,7 @@ message GetBootstrapDataResponse {
   // This should not be set if the device does not check for ownership
   // voucher, which is indicated by the device not setting the nonce field
   // in the GetBootstrapDataRequest message.
-    string response_signature = 103;
+  string response_signature = 103;
 }
 
 message SoftwareImage {


### PR DESCRIPTION
Add the support of skipping ownership validation in Bootz.

There are 3 sequentially dependent PRs to introduce this changes.

1. [This PR] [Bootz API PR](https://github.com/openconfig/bootz/pull/5) updates Bootz API and README.
2. [OC modeling PR](https://github.com/openconfig/public/pull/908) updates Bootz OpenConfig modeling.
3. [FP test PR](https://github.com/openconfig/featureprofiles/pull/1864) updates feature profile tests