### PR TITLE
Correct import renaming for generated protobuf packages

### DIFF
--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/openconfig/bootz/proto/bootz"
 	"github.com/openconfig/bootz/server/service"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,6 +36,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	log "github.com/golang/glog"
+	bpb "github.com/openconfig/bootz/proto/bootz"
 	epb "github.com/openconfig/bootz/server/entitymanager/proto/entity"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )
@@ -48,7 +48,7 @@ type InMemoryEntityManager struct {
 	// inventory represents an organization's inventory of owned chassis.
 	chassisInventory map[service.EntityLookup]*epb.Chassis
 	// represents the current status of known control cards
-	controlCardStatuses map[string]bootz.ControlCardState_ControlCardStatus
+	controlCardStatuses map[string]bpb.ControlCardState_ControlCardStatus
 	// stores the defaut config such as security artifacts dir.
 	defaults *epb.Options
 	// security artifacts  (OVs, OC and PDC).
@@ -79,8 +79,8 @@ func readOCConfig(path string) ([]byte, error) {
 	return data, nil
 }
 
-func populateBootConfig(conf *epb.BootConfig) (*bootz.BootConfig, error) {
-	bootConfig := &bootz.BootConfig{}
+func populateBootConfig(conf *epb.BootConfig) (*bpb.BootConfig, error) {
+	bootConfig := &bpb.BootConfig{}
 	if conf.GetOcConfigFile() != "" {
 		ocConf, err := readOCConfig(conf.GetOcConfigFile())
 		if err != nil {
@@ -102,7 +102,7 @@ func populateBootConfig(conf *epb.BootConfig) (*bootz.BootConfig, error) {
 }
 
 // GetBootstrapData fetches and returns the bootstrap data response from the server.
-func (m *InMemoryEntityManager) GetBootstrapData(chassis *service.EntityLookup, controllerCard *bootz.ControlCard) (*bootz.BootstrapDataResponse, error) {
+func (m *InMemoryEntityManager) GetBootstrapData(chassis *service.EntityLookup, controllerCard *bpb.ControlCard) (*bpb.BootstrapDataResponse, error) {
 	// First check if we are expecting this control card.
 	if controllerCard.SerialNumber == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "no serial number provided")
@@ -126,7 +126,7 @@ func (m *InMemoryEntityManager) GetBootstrapData(chassis *service.EntityLookup, 
 		return nil, status.Errorf(codes.NotFound, "could not find Controller with serial#: %s and partnumber: %s belonging to chassis %s", controllerCard.GetSerialNumber(), controllerCard.GetPartNumber(), chassis.SerialNumber)
 	}
 	// TODO: for now add status for the controller card. We may need to move all runtime info to bootz service.
-	m.controlCardStatuses[controllerCard.GetSerialNumber()] = bootz.ControlCardState_CONTROL_CARD_STATUS_UNSPECIFIED
+	m.controlCardStatuses[controllerCard.GetSerialNumber()] = bpb.ControlCardState_CONTROL_CARD_STATUS_UNSPECIFIED
 
 	bootCfg, err := populateBootConfig(ch.GetConfig().GetBootConfig())
 	if err != nil {
@@ -135,19 +135,19 @@ func (m *InMemoryEntityManager) GetBootstrapData(chassis *service.EntityLookup, 
 	log.Infof("Control card located in inventory")
 
 	// TODO: Populate ServerTrustCert and gnsi config
-	return &bootz.BootstrapDataResponse{
+	return &bpb.BootstrapDataResponse{
 		SerialNum:        controllerCard.SerialNumber,
 		IntendedImage:    ch.GetSoftwareImage(),
 		BootPasswordHash: ch.BootloaderPasswordHash,
 		ServerTrustCert:  "FakeTLSCert",
 		BootConfig:       bootCfg,
-		Credentials:      &bootz.Credentials{},
+		Credentials:      &bpb.Credentials{},
 		// TODO: Populate pathz, authz and certificates.
 	}, nil
 }
 
 // SetStatus updates the status for each control card on the chassis.
-func (m *InMemoryEntityManager) SetStatus(req *bootz.ReportStatusRequest) error {
+func (m *InMemoryEntityManager) SetStatus(req *bpb.ReportStatusRequest) error {
 	if len(req.GetStates()) == 0 {
 		return status.Errorf(codes.InvalidArgument, "no control card states provided")
 	}
@@ -220,7 +220,7 @@ func parseSecurityArtifacts(artifactDir string) (*service.SecurityArtifacts, err
 }
 
 // Sign unmarshals the SignedResponse bytes then generates a signature from its Ownership Certificate private key.
-func (m *InMemoryEntityManager) Sign(resp *bootz.GetBootstrapDataResponse, chassis *service.EntityLookup, controllerCard string) error {
+func (m *InMemoryEntityManager) Sign(resp *bpb.GetBootstrapDataResponse, chassis *service.EntityLookup, controllerCard string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// check if sec artifacts areprovided for signing
@@ -280,7 +280,7 @@ func (m *InMemoryEntityManager) fetchOwnershipVoucher(chassis *service.EntityLoo
 	if !ok {
 		return "", status.Errorf(codes.NotFound, "could not find chassis with serial#: %s and manufacturer: %s", chassis.SerialNumber, chassis.Manufacturer)
 	}
-	//cc:=&bootz.ControlCard{}
+	//cc:=&bpb.ControlCard{}
 	for _, c := range ch.GetControllerCards() {
 		if c.GetSerialNumber() == ccSerial {
 			return c.GetOwnershipVoucher(), nil
@@ -293,13 +293,13 @@ func (m *InMemoryEntityManager) fetchOwnershipVoucher(chassis *service.EntityLoo
 func (m *InMemoryEntityManager) AddControlCard(serial string) *InMemoryEntityManager {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.controlCardStatuses[serial] = bootz.ControlCardState_CONTROL_CARD_STATUS_UNSPECIFIED
+	m.controlCardStatuses[serial] = bpb.ControlCardState_CONTROL_CARD_STATUS_UNSPECIFIED
 	log.Infof("Added control card %v to server entity manager", serial)
 	return m
 }
 
 // AddChassis adds a new chassis to the entity manager.
-func (m *InMemoryEntityManager) AddChassis(bootMode bootz.BootMode, manufacturer string, serial string) *InMemoryEntityManager {
+func (m *InMemoryEntityManager) AddChassis(bootMode bpb.BootMode, manufacturer string, serial string) *InMemoryEntityManager {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	l := service.EntityLookup{
@@ -319,7 +319,7 @@ func (m *InMemoryEntityManager) AddChassis(bootMode bootz.BootMode, manufacturer
 func New(chassisConfigFile string) (*InMemoryEntityManager, error) {
 	newManager := &InMemoryEntityManager{
 		chassisInventory:    map[service.EntityLookup]*epb.Chassis{},
-		controlCardStatuses: map[string]bootz.ControlCardState_ControlCardStatus{},
+		controlCardStatuses: map[string]bpb.ControlCardState_ControlCardStatus{},
 	}
 	if chassisConfigFile == "" {
 		return newManager, nil

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -27,10 +27,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/h-fam/errdiff"
-	"github.com/openconfig/bootz/proto/bootz"
 	"github.com/openconfig/bootz/server/entitymanager/proto/entity"
 	"github.com/openconfig/bootz/server/service"
 	"google.golang.org/protobuf/proto"
+
+	bpb "github.com/openconfig/bootz/proto/bootz"
 )
 
 func TestNew(t *testing.T) {
@@ -41,13 +42,13 @@ func TestNew(t *testing.T) {
 		SerialNumber:           "123",
 		Manufacturer:           "Cisco",
 		BootloaderPasswordHash: "ABCD123",
-		BootMode:               bootz.BootMode_BOOT_MODE_INSECURE,
+		BootMode:               bpb.BootMode_BOOT_MODE_INSECURE,
 		Config: &entity.Config{
 			BootConfig: &entity.BootConfig{},
 			DhcpConfig: &entity.DHCPConfig{},
 			GnsiConfig: &entity.GNSIConfig{},
 		},
-		SoftwareImage: &bootz.SoftwareImage{
+		SoftwareImage: &bpb.SoftwareImage{
 			Name:          "Default Image",
 			Version:       "1.0",
 			Url:           "https://path/to/image",
@@ -113,7 +114,7 @@ func TestNew(t *testing.T) {
 			inv, err := New(test.chassisConf)
 			if err == nil {
 				opts := []cmp.Option{
-					cmpopts.IgnoreUnexported(entity.Chassis{}, entity.Options{}, bootz.SoftwareImage{}, entity.DHCPConfig{}, entity.GNSIConfig{}, entity.BootConfig{}, entity.Config{}, entity.BootConfig{}, entity.ControlCard{}, service.EntityLookup{}),
+					cmpopts.IgnoreUnexported(entity.Chassis{}, entity.Options{}, bpb.SoftwareImage{}, entity.DHCPConfig{}, entity.GNSIConfig{}, entity.BootConfig{}, entity.Config{}, entity.BootConfig{}, entity.ControlCard{}, service.EntityLookup{}),
 				}
 				if !cmp.Equal(inv.chassisInventory, test.inventory, opts...) {
 					t.Errorf("Inventory list is not as expected, Diff: %s", cmp.Diff(inv.chassisInventory, test.inventory, opts...))
@@ -138,13 +139,13 @@ func TestFetchOwnershipVoucher(t *testing.T) {
 		SerialNumber:           "123",
 		Manufacturer:           "Cisco",
 		BootloaderPasswordHash: "ABCD123",
-		BootMode:               bootz.BootMode_BOOT_MODE_INSECURE,
+		BootMode:               bpb.BootMode_BOOT_MODE_INSECURE,
 		Config: &entity.Config{
 			BootConfig: &entity.BootConfig{},
 			DhcpConfig: &entity.DHCPConfig{},
 			GnsiConfig: &entity.GNSIConfig{},
 		},
-		SoftwareImage: &bootz.SoftwareImage{
+		SoftwareImage: &bpb.SoftwareImage{
 			Name:          "Default Image",
 			Version:       "1.0",
 			Url:           "https://path/to/image",
@@ -210,7 +211,7 @@ func TestResolveChassis(t *testing.T) {
 			Manufacturer: "Cisco",
 		},
 		want: &service.ChassisEntity{
-			BootMode: bootz.BootMode_BOOT_MODE_SECURE,
+			BootMode: bpb.BootMode_BOOT_MODE_SECURE,
 		},
 	}, {
 		desc: "Chassis Not Found",
@@ -223,7 +224,7 @@ func TestResolveChassis(t *testing.T) {
 	},
 	}
 	em, _ := New("")
-	em.AddChassis(bootz.BootMode_BOOT_MODE_SECURE, "Cisco", "123")
+	em.AddChassis(bpb.BootMode_BOOT_MODE_SECURE, "Cisco", "123")
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -244,7 +245,7 @@ func TestSign(t *testing.T) {
 		desc    string
 		chassis service.EntityLookup
 		serial  string
-		resp    *bootz.GetBootstrapDataResponse
+		resp    *bpb.GetBootstrapDataResponse
 		wantOV  string
 		wantOC  bool
 		wantErr bool
@@ -255,9 +256,9 @@ func TestSign(t *testing.T) {
 			SerialNumber: "123",
 		},
 		serial: "123A",
-		resp: &bootz.GetBootstrapDataResponse{
-			SignedResponse: &bootz.BootstrapDataSigned{
-				Responses: []*bootz.BootstrapDataResponse{
+		resp: &bpb.GetBootstrapDataResponse{
+			SignedResponse: &bpb.BootstrapDataSigned{
+				Responses: []*bpb.BootstrapDataResponse{
 					{SerialNum: "123A"},
 				},
 			},
@@ -267,7 +268,7 @@ func TestSign(t *testing.T) {
 		wantErr: false,
 	}, {
 		desc:    "Empty response",
-		resp:    &bootz.GetBootstrapDataResponse{},
+		resp:    &bpb.GetBootstrapDataResponse{},
 		wantErr: true,
 	},
 	}
@@ -326,37 +327,37 @@ func TestSign(t *testing.T) {
 func TestSetStatus(t *testing.T) {
 	tests := []struct {
 		desc    string
-		input   *bootz.ReportStatusRequest
+		input   *bpb.ReportStatusRequest
 		wantErr bool
 	}{{
 		desc: "No control card states",
-		input: &bootz.ReportStatusRequest{
-			Status:        bootz.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
+		input: &bpb.ReportStatusRequest{
+			Status:        bpb.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
 			StatusMessage: "Bootstrap status succeeded",
 		},
 		wantErr: true,
 	}, {
 		desc: "Control card initialized",
-		input: &bootz.ReportStatusRequest{
-			Status:        bootz.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
+		input: &bpb.ReportStatusRequest{
+			Status:        bpb.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
 			StatusMessage: "Bootstrap status succeeded",
-			States: []*bootz.ControlCardState{
+			States: []*bpb.ControlCardState{
 				{
 					SerialNumber: "123A",
-					Status:       *bootz.ControlCardState_CONTROL_CARD_STATUS_INITIALIZED.Enum(),
+					Status:       *bpb.ControlCardState_CONTROL_CARD_STATUS_INITIALIZED.Enum(),
 				},
 			},
 		},
 		wantErr: false,
 	}, {
 		desc: "Unknown control card",
-		input: &bootz.ReportStatusRequest{
-			Status:        bootz.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
+		input: &bpb.ReportStatusRequest{
+			Status:        bpb.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
 			StatusMessage: "Bootstrap status succeeded",
-			States: []*bootz.ControlCardState{
+			States: []*bpb.ControlCardState{
 				{
 					SerialNumber: "123C",
-					Status:       *bootz.ControlCardState_CONTROL_CARD_STATUS_INITIALIZED.Enum(),
+					Status:       *bpb.ControlCardState_CONTROL_CARD_STATUS_INITIALIZED.Enum(),
 				},
 			},
 		},
@@ -364,7 +365,7 @@ func TestSetStatus(t *testing.T) {
 	},
 	}
 	em, _ := New("")
-	em.AddChassis(bootz.BootMode_BOOT_MODE_SECURE, "Cisco", "123").AddControlCard("123A")
+	em.AddChassis(bpb.BootMode_BOOT_MODE_SECURE, "Cisco", "123").AddControlCard("123A")
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -384,13 +385,13 @@ func TestGetBootstrapData(t *testing.T) {
 		SerialNumber:           "123",
 		Manufacturer:           "Cisco",
 		BootloaderPasswordHash: "ABCD123",
-		BootMode:               bootz.BootMode_BOOT_MODE_INSECURE,
+		BootMode:               bpb.BootMode_BOOT_MODE_INSECURE,
 		Config: &entity.Config{
 			BootConfig: &entity.BootConfig{},
 			DhcpConfig: &entity.DHCPConfig{},
 			GnsiConfig: &entity.GNSIConfig{},
 		},
-		SoftwareImage: &bootz.SoftwareImage{
+		SoftwareImage: &bpb.SoftwareImage{
 			Name:          "Default Image",
 			Version:       "1.0",
 			Url:           "https://path/to/image",
@@ -412,28 +413,28 @@ func TestGetBootstrapData(t *testing.T) {
 	}
 	tests := []struct {
 		desc    string
-		input   *bootz.ControlCard
-		want    *bootz.BootstrapDataResponse
+		input   *bpb.ControlCard
+		want    *bpb.BootstrapDataResponse
 		wantErr bool
 	}{{
 		desc:    "No serial number",
-		input:   &bootz.ControlCard{},
+		input:   &bpb.ControlCard{},
 		wantErr: true,
 	}, {
 		desc: "Control card not found",
-		input: &bootz.ControlCard{
+		input: &bpb.ControlCard{
 			SerialNumber: "456A",
 		},
 		wantErr: true,
 	}, {
 		desc: "Successful bootstrap",
-		input: &bootz.ControlCard{
+		input: &bpb.ControlCard{
 			SerialNumber: "123A",
 			PartNumber:   "123A",
 		},
-		want: &bootz.BootstrapDataResponse{
+		want: &bpb.BootstrapDataResponse{
 			SerialNum: "123A",
-			IntendedImage: &bootz.SoftwareImage{
+			IntendedImage: &bpb.SoftwareImage{
 				Name:          "Default Image",
 				Version:       "1.0",
 				Url:           "https://path/to/image",
@@ -442,11 +443,11 @@ func TestGetBootstrapData(t *testing.T) {
 			},
 			BootPasswordHash: "ABCD123",
 			ServerTrustCert:  "FakeTLSCert",
-			BootConfig: &bootz.BootConfig{
+			BootConfig: &bpb.BootConfig{
 				VendorConfig: []byte(""),
 				OcConfig:     []byte(""),
 			},
-			Credentials: &bootz.Credentials{},
+			Credentials: &bpb.Credentials{},
 		},
 		wantErr: false,
 	},
@@ -481,7 +482,7 @@ func TestLoadConfig(t *testing.T) {
 	tests := []struct {
 		desc             string
 		bootConfig       *entity.BootConfig
-		wantBootConfig   *bootz.BootConfig
+		wantBootConfig   *bpb.BootConfig
 		wantVendorConfig []byte
 		wantErr          string
 	}{
@@ -491,7 +492,7 @@ func TestLoadConfig(t *testing.T) {
 				VendorConfigFile: "../../testdata/cisco.cfg",
 				OcConfigFile:     "../../testdata/oc_config.prototext",
 			},
-			wantBootConfig: &bootz.BootConfig{
+			wantBootConfig: &bpb.BootConfig{
 				VendorConfig: []byte(vendorCliConfig),
 			},
 			wantVendorConfig: []byte{},
@@ -503,7 +504,7 @@ func TestLoadConfig(t *testing.T) {
 				VendorConfigFile: "../../testdata/cisco.cfg",
 				OcConfigFile:     "../../testdata/wrong_oc_config.prototext",
 			},
-			wantBootConfig: &bootz.BootConfig{
+			wantBootConfig: &bpb.BootConfig{
 				VendorConfig: []byte(vendorCliConfig),
 			},
 			wantVendorConfig: []byte{},
@@ -515,7 +516,7 @@ func TestLoadConfig(t *testing.T) {
 				VendorConfigFile: "../../testdata/cisco.cfg",
 				OcConfigFile:     "../../wrong_path.prototext",
 			},
-			wantBootConfig: &bootz.BootConfig{
+			wantBootConfig: &bpb.BootConfig{
 				VendorConfig: []byte(vendorCliConfig),
 			},
 			wantVendorConfig: []byte{},
@@ -527,7 +528,7 @@ func TestLoadConfig(t *testing.T) {
 				VendorConfigFile: "../../wrong/path",
 				OcConfigFile:     "../../testdata/oc_config.prototext",
 			},
-			wantBootConfig: &bootz.BootConfig{
+			wantBootConfig: &bpb.BootConfig{
 				VendorConfig: []byte(vendorCliConfig),
 			},
 			wantVendorConfig: []byte{},

--- a/server/server.go
+++ b/server/server.go
@@ -29,13 +29,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openconfig/bootz/proto/bootz"
 	"github.com/openconfig/bootz/server/entitymanager"
 	"github.com/openconfig/bootz/server/service"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	log "github.com/golang/glog"
+	bpb "github.com/openconfig/bootz/proto/bootz"
 )
 
 var (
@@ -169,7 +169,7 @@ func main() {
 	}
 	log.Infof("Server ready and listening on %s", lis.Addr())
 	log.Infof("=============================================================================")
-	bootz.RegisterBootstrapServer(s, c)
+	bpb.RegisterBootstrapServer(s, c)
 	err = s.Serve(lis)
 	if err != nil {
 		log.Exitf("Error serving grpc: %v", err)

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -19,12 +19,12 @@ import (
 	"context"
 	"crypto/tls"
 
-	"github.com/openconfig/bootz/proto/bootz"
 	"github.com/openconfig/gnmi/errlist"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	log "github.com/golang/glog"
+	bpb "github.com/openconfig/bootz/proto/bootz"
 )
 
 // OVList is a mapping of control card serial number to ownership voucher.
@@ -63,24 +63,24 @@ type EntityLookup struct {
 // ChassisEntity provides the mode that the system is currently
 // configured.
 type ChassisEntity struct {
-	BootMode bootz.BootMode
+	BootMode bpb.BootMode
 }
 
 // EntityManager maintains the entities and their states.
 type EntityManager interface {
 	ResolveChassis(*EntityLookup) (*ChassisEntity, error)
-	GetBootstrapData(*EntityLookup, *bootz.ControlCard) (*bootz.BootstrapDataResponse, error)
-	SetStatus(*bootz.ReportStatusRequest) error
-	Sign(*bootz.GetBootstrapDataResponse, *EntityLookup, string) error
+	GetBootstrapData(*EntityLookup, *bpb.ControlCard) (*bpb.BootstrapDataResponse, error)
+	SetStatus(*bpb.ReportStatusRequest) error
+	Sign(*bpb.GetBootstrapDataResponse, *EntityLookup, string) error
 }
 
 // Service represents the server and entity manager.
 type Service struct {
-	bootz.UnimplementedBootstrapServer
+	bpb.UnimplementedBootstrapServer
 	em EntityManager
 }
 
-func (s *Service) GetBootstrapData(ctx context.Context, req *bootz.GetBootstrapDataRequest) (*bootz.GetBootstrapDataResponse, error) {
+func (s *Service) GetBootstrapData(ctx context.Context, req *bpb.GetBootstrapDataRequest) (*bpb.GetBootstrapDataResponse, error) {
 	log.Infof("=============================================================================")
 	log.Infof("==================== Received request for bootstrap data ====================")
 	log.Infof("=============================================================================")
@@ -101,7 +101,7 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bootz.GetBootstrapD
 	log.Infof("Verified server can resolve chassis")
 
 	// If chassis can only be booted into secure mode then return error
-	if chassis.BootMode == bootz.BootMode_BOOT_MODE_SECURE && req.Nonce == "" {
+	if chassis.BootMode == bpb.BootMode_BOOT_MODE_SECURE && req.Nonce == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "chassis requires secure boot only")
 	}
 
@@ -111,7 +111,7 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bootz.GetBootstrapD
 	log.Infof("=============================================================================")
 	log.Infof("==================== Fetching data for each control card ====================")
 	log.Infof("=============================================================================")
-	var responses []*bootz.BootstrapDataResponse
+	var responses []*bpb.BootstrapDataResponse
 	for _, v := range req.ChassisDescriptor.ControlCards {
 		bootdata, err := s.em.GetBootstrapData(lookup, v)
 		if err != nil {
@@ -126,8 +126,8 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bootz.GetBootstrapD
 	log.Infof("Successfully fetched data for each control card")
 	log.Infof("=============================================================================")
 
-	resp := &bootz.GetBootstrapDataResponse{
-		SignedResponse: &bootz.BootstrapDataSigned{
+	resp := &bpb.GetBootstrapDataResponse{
+		SignedResponse: &bpb.BootstrapDataSigned{
 			Responses: responses,
 		},
 	}
@@ -148,11 +148,11 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bootz.GetBootstrapD
 	return resp, nil
 }
 
-func (s *Service) ReportStatus(ctx context.Context, req *bootz.ReportStatusRequest) (*bootz.EmptyResponse, error) {
+func (s *Service) ReportStatus(ctx context.Context, req *bpb.ReportStatusRequest) (*bpb.EmptyResponse, error) {
 	log.Infof("=============================================================================")
 	log.Infof("========================== Status report received ===========================")
 	log.Infof("=============================================================================")
-	return &bootz.EmptyResponse{}, s.em.SetStatus(req)
+	return &bpb.EmptyResponse{}, s.em.SetStatus(req)
 }
 
 // SetDeviceConfiguration is a public API for allowing the device configuration to be set for each device the


### PR DESCRIPTION
Generated protocol buffer packages must be renamed to remove underscores from their names, and their aliases must have a pb suffix.