### PR TITLE
Remove dhcp_config field from inventory data as it does not exist in the proto message.

### DIFF
--- a/regenerate-files.sh
+++ b/regenerate-files.sh
@@ -18,6 +18,7 @@ copy_generated() {
 }
 
 bazel build //proto:all
+bazel build //server/entitymanager/proto:all
 # first arg is the package name, second arg is namespace for the package, and thrid is the location where the generated code will be saved. 
 copy_generated "bootz"  ${BOOTZ_NS}   "proto/"
 copy_generated "entity"  ${ENTITY_NS} "server/entitymanager/proto/"  

--- a/server/entitymanager/testdata/chassis.prototxt
+++ b/server/entitymanager/testdata/chassis.prototxt
@@ -26,9 +26,5 @@ chassis {
         gnsi_config {
 
         }
-        dhcp_config {
-            
-        }
-
     }
 }

--- a/testdata/inventory_local.prototxt
+++ b/testdata/inventory_local.prototxt
@@ -30,7 +30,5 @@ chassis {
         }
         gnsi_config {
         }
-        dhcp_config {
-        }
     }
 }

--- a/testdata/wrong_inventory.prototxt
+++ b/testdata/wrong_inventory.prototxt
@@ -23,7 +23,5 @@ chassis {
         }
         gnsi_config {
         }
-        dhcp_config {
-        }
     }
 }


### PR DESCRIPTION
Also regenerate-files.sh script to build the entitymanager proto rules.