### PR TITLE
Don't actually start the server during the test.

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -22,15 +22,8 @@ import (
 // TestStartup tests that a gRPC server can be created with the default flags.
 func TestStartup(t *testing.T) {
 	flag.Parse()
-	s, err := newServer()
+	_, err := newServer()
 	if err != nil {
 		t.Fatalf("newServer() err = %v, want nil", err)
 	}
-	go func() {
-		err = s.Start()
-		if err != nil {
-			t.Errorf("Error serving grpc: %v", err)
-		}
-	}()
-	s.Stop()
 }


### PR DESCRIPTION
Starting the server this way caused issues with different goroutines logging things after the test had finished. Instead we just check that the server can be created. For a full end-to-end test of the server, we should set up integration tests intead.