### PR TITLE
Populate authz file location for local runs.

### DIFF
--- a/testdata/inventory_local.prototxt
+++ b/testdata/inventory_local.prototxt
@@ -1,6 +1,9 @@
 options {
     bootzserver: "bootzip:...."
     artifact_dir: "../testdata/"
+    gnsi_global_config:{
+        authz_upload_file:"../testdata/authz.prototext"
+    }
 }
 chassis {
     name: "test"


### PR DESCRIPTION
Authz was fixed in https://github.com/openconfig/bootz/pull/50 however this one inventory file was not updated.