### PR TITLE
Return Owner Cert as a CMS structure instead of PEM encoding

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -91,15 +91,11 @@ func validateArtifacts(serialNumber string, resp *bpb.GetBootstrapDataResponse) 
 
 	// Parse the Ownership Certificate.
 	log.Infof("Parsing the OC")
-	ocDER, err := ownercertificate.Verify(resp.GetOwnershipCertificate(), pdcPool)
+	ocCert, err := ownercertificate.Verify(resp.GetOwnershipCertificate(), pdcPool)
 	if err != nil {
 		return err
 	}
 	log.Infof("Validated ownership certificate with OV PDC")
-	ocCert, err := x509.ParseCertificate(ocDER)
-	if err != nil {
-		return err
-	}
 
 	// Validate the response signature.
 	log.Infof("=============================================================================")

--- a/client/client.go
+++ b/client/client.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	ownercertificate "github.com/openconfig/bootz/common/owner_certificate"
 	ownershipvoucher "github.com/openconfig/bootz/common/ownership_voucher"
 	"github.com/openconfig/bootz/common/signature"
 
@@ -72,11 +73,6 @@ func validateArtifacts(serialNumber string, resp *bpb.GetBootstrapDataResponse) 
 	log.Infof("Validated ownership voucher signed by vendor")
 	log.Infof("=============================================================================")
 
-	oc := resp.GetOwnershipCertificate()
-	if len(oc) == 0 {
-		return fmt.Errorf("received empty ownership certificate from server")
-	}
-
 	// Verify the serial number for this OV
 	log.Infof("Verifying the serial number for this OV")
 	if parsedOV.OV.SerialNumber != serialNumber {
@@ -95,21 +91,15 @@ func validateArtifacts(serialNumber string, resp *bpb.GetBootstrapDataResponse) 
 
 	// Parse the Ownership Certificate.
 	log.Infof("Parsing the OC")
-	ocCert, err := x509.ParseCertificate(oc)
+	ocDER, err := ownercertificate.Verify(resp.GetOwnershipCertificate(), pdcPool)
 	if err != nil {
-		return fmt.Errorf("failed to parse certificate: %v", err)
-	}
-
-	// Verify that the OC is signed by the PDC.
-	log.Infof("Verifying that the OC is signed by the PDC")
-	opts := x509.VerifyOptions{
-		Roots:         pdcPool,
-		Intermediates: x509.NewCertPool(),
-	}
-	if _, err := ocCert.Verify(opts); err != nil {
 		return err
 	}
 	log.Infof("Validated ownership certificate with OV PDC")
+	ocCert, err := x509.ParseCertificate(ocDER)
+	if err != nil {
+		return err
+	}
 
 	// Validate the response signature.
 	log.Infof("=============================================================================")

--- a/common/owner_certificate/owner_certificate.go
+++ b/common/owner_certificate/owner_certificate.go
@@ -40,7 +40,7 @@ func Verify(in []byte, certPool *x509.CertPool) ([]byte, error) {
 }
 
 // GenerateCMS takes an Ownership Certificate keypair and converts it to a CMS structure.
-// The returned CMS object is the DER-encoded Owner Certificiate.
+// The returned CMS object is the DER-encoded Owner Certificate.
 func GenerateCMS(cert *x509.Certificate, priv crypto.PrivateKey) ([]byte, error) {
 	signedMessage, err := pkcs7.NewSignedData(cert.Raw)
 	if err != nil {

--- a/common/owner_certificate/owner_certificate.go
+++ b/common/owner_certificate/owner_certificate.go
@@ -43,7 +43,7 @@ func Verify(in []byte, certPool *x509.CertPool) (*x509.Certificate, error) {
 }
 
 // GenerateCMS takes an Ownership Certificate keypair and converts it to a CMS structure.
-// The returned CMS object is the DER-encoded Owner Certificate.
+// The CMS structure contains the Ownership Certificate in its list of certificates.
 func GenerateCMS(cert *x509.Certificate, priv crypto.PrivateKey) ([]byte, error) {
 	signedMessage, err := pkcs7.NewSignedData(nil)
 	if err != nil {

--- a/common/owner_certificate/owner_certificate.go
+++ b/common/owner_certificate/owner_certificate.go
@@ -1,0 +1,58 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ownercertificate provides helper functions for generating, parsing and verifying owner certs.
+package ownercertificate
+
+import (
+	"crypto"
+	"crypto/x509"
+	"fmt"
+
+	"go.mozilla.org/pkcs7"
+)
+
+// Verify checks that the provided CMS value is signed by a signer in the provided
+// certPool and returns the pkcs7 content.
+func Verify(in []byte, certPool *x509.CertPool) ([]byte, error) {
+	if len(in) == 0 {
+		return nil, fmt.Errorf("owner certificate is empty")
+	}
+	p7, err := pkcs7.Parse(in)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse into pkcs7 format: %v", err)
+	}
+	if err = p7.VerifyWithChain(certPool); err != nil {
+		return nil, fmt.Errorf("failed to verify OC: %v", err)
+	}
+	return p7.Content, nil
+}
+
+// GenerateCMS takes an Ownership Certificate keypair and converts it to a CMS structure.
+// The returned CMS object is the DER-encoded Owner Certificiate.
+func GenerateCMS(cert *x509.Certificate, priv crypto.PrivateKey) ([]byte, error) {
+	signedMessage, err := pkcs7.NewSignedData(cert.Raw)
+	if err != nil {
+		return nil, err
+	}
+	signedMessage.SetDigestAlgorithm(pkcs7.OIDDigestAlgorithmSHA256)
+	signedMessage.SetEncryptionAlgorithm(pkcs7.OIDEncryptionAlgorithmRSA)
+
+	err = signedMessage.AddSigner(cert, priv, pkcs7.SignerInfoConfig{})
+	if err != nil {
+		return nil, err
+	}
+
+	return signedMessage.Finish()
+}

--- a/common/owner_certificate/owner_certificate_test.go
+++ b/common/owner_certificate/owner_certificate_test.go
@@ -1,0 +1,76 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ownercertificate
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	_ "embed"
+)
+
+var (
+	//go:embed testdata/oc_pub.pem
+	ocPub []byte
+	//go:embed testdata/pdc_pub.pem
+	pdcPub []byte
+	//go:embed testdata/oc_priv.pem
+	ocPriv []byte
+)
+
+// Tests that the CMS structure can be created and that it can be verified with a PDC.
+func TestGenerateAndVerify(t *testing.T) {
+	block, _ := pem.Decode(ocPub)
+	if block == nil {
+		t.Fatalf("error decoding OC certificate")
+	}
+	ownerCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ = pem.Decode(ocPriv)
+	if block == nil {
+		t.Fatalf("error decoding OC private key")
+	}
+	ownerCertPrivateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ = pem.Decode(pdcPub)
+	if block == nil {
+		t.Fatalf("error decoding PDC certificate")
+	}
+	pdcCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cms, err := GenerateCMS(ownerCert, ownerCertPrivateKey)
+	if err != nil {
+		t.Fatalf("error generating CMS: %v", err)
+	}
+	pdcPool := x509.NewCertPool()
+	pdcPool.AddCert(pdcCert)
+	ocDER, err := Verify(cms, pdcPool)
+	if err != nil {
+		t.Fatalf("error verifying OC: %v", err)
+	}
+	// Finally, make sure we can parse the DER.
+	_, err = x509.ParseCertificate(ocDER)
+	if err != nil {
+		t.Fatalf("error parsing returned OC")
+	}
+
+}

--- a/common/owner_certificate/owner_certificate_test.go
+++ b/common/owner_certificate/owner_certificate_test.go
@@ -63,14 +63,9 @@ func TestGenerateAndVerify(t *testing.T) {
 	}
 	pdcPool := x509.NewCertPool()
 	pdcPool.AddCert(pdcCert)
-	ocDER, err := Verify(cms, pdcPool)
+	_, err = Verify(cms, pdcPool)
 	if err != nil {
 		t.Fatalf("error verifying OC: %v", err)
-	}
-	// Finally, make sure we can parse the DER.
-	_, err = x509.ParseCertificate(ocDER)
-	if err != nil {
-		t.Fatalf("error parsing returned OC")
 	}
 
 }

--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -273,7 +273,11 @@ func (m *InMemoryEntityManager) Sign(resp *bpb.GetBootstrapDataResponse, chassis
 	log.Infof("OV populated")
 
 	// Populate the OC
-	resp.OwnershipCertificate = m.secArtifacts.OwnerCert.Raw
+	ocCMS, err := ownercertificate.GenerateCMS(m.secArtifacts.OwnerCert, m.secArtifacts.OwnerCertPrivateKey)
+	if err != nil {
+		return err
+	}
+	resp.OwnershipCertificate = ocCMS
 	log.Infof("OC populated")
 	return nil
 }

--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sync"
 
+	ownercertificate "github.com/openconfig/bootz/common/owner_certificate"
 	"github.com/openconfig/bootz/common/signature"
 	"github.com/openconfig/bootz/server/service"
 	"google.golang.org/grpc/codes"

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -16,7 +16,6 @@ package entitymanager
 
 import (
 	"bytes"
-	"bytes"
 	"encoding/base64"
 	"os"
 	"testing"
@@ -316,12 +315,12 @@ func TestSign(t *testing.T) {
 			if !bytes.Equal(test.resp.GetOwnershipVoucher(), a.OV[test.serial]) {
 				t.Errorf("Sign() ov = %v, want %v", test.resp.GetOwnershipVoucher(), a.OV[test.serial])
 			}
-			wantOC, err := ownercertificate.GenerateCMS(cert, priv)
+			wantOC, err := ownercertificate.GenerateCMS(a.OwnerCert, a.OwnerCertPrivateKey)
 			if err != nil {
 				t.Fatalf("unable to generate OC CMS: %v", err)
 			}
 			if test.wantOC {
-				if !bytes.Equal(test.resp.GetOwnershipCertificate(), a.OwnerCert.Raw) {
+				if !bytes.Equal(test.resp.GetOwnershipCertificate(), wantOC) {
 					t.Errorf("Sign() oc = %v, want %v", test.resp.GetOwnershipCertificate(), a.OwnerCert.Raw)
 				}
 			}

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -16,6 +16,7 @@ package entitymanager
 
 import (
 	"bytes"
+	"bytes"
 	"encoding/base64"
 	"os"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/h-fam/errdiff"
+	ownercertificate "github.com/openconfig/bootz/common/owner_certificate"
 	"github.com/openconfig/bootz/common/signature"
 	"github.com/openconfig/bootz/server/service"
 	artifacts "github.com/openconfig/bootz/testdata"
@@ -313,6 +315,10 @@ func TestSign(t *testing.T) {
 			}
 			if !bytes.Equal(test.resp.GetOwnershipVoucher(), a.OV[test.serial]) {
 				t.Errorf("Sign() ov = %v, want %v", test.resp.GetOwnershipVoucher(), a.OV[test.serial])
+			}
+			wantOC, err := ownercertificate.GenerateCMS(cert, priv)
+			if err != nil {
+				t.Fatalf("unable to generate OC CMS: %v", err)
 			}
 			if test.wantOC {
 				if !bytes.Equal(test.resp.GetOwnershipCertificate(), a.OwnerCert.Raw) {


### PR DESCRIPTION
From https://www.rfc-editor.org/rfc/rfc8572.html#section-3.2, this field should be a CMS structure, not a PEM encoding.