### PR TITLE
Refactor EntityManager to use a slice of Entities instead of a map.

### DIFF
--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -16,6 +16,7 @@
 package entitymanager
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -54,7 +55,7 @@ type InMemoryEntityManager struct {
 
 // ResolveChassis returns an entity based on the provided lookup.
 // If a control card serial is provided, it also looks up chassis' by its control cards.
-func (m *InMemoryEntityManager) ResolveChassis(lookup *service.EntityLookup, ccSerial string) (*service.ChassisEntity, error) {
+func (m *InMemoryEntityManager) ResolveChassis(ctx context.Context, lookup *service.EntityLookup, ccSerial string) (*service.ChassisEntity, error) {
 	chassis, err := m.lookupChassis(lookup, ccSerial)
 	if err != nil {
 		return nil, err
@@ -152,7 +153,7 @@ func populateBootConfig(conf *epb.BootConfig) (*bpb.BootConfig, error) {
 }
 
 // GetBootstrapData fetches and returns the bootstrap data response from the server.
-func (m *InMemoryEntityManager) GetBootstrapData(lookup *service.EntityLookup, controllerCard *bpb.ControlCard) (*bpb.BootstrapDataResponse, error) {
+func (m *InMemoryEntityManager) GetBootstrapData(ctx context.Context, lookup *service.EntityLookup, controllerCard *bpb.ControlCard) (*bpb.BootstrapDataResponse, error) {
 	serial := lookup.SerialNumber
 	if controllerCard != nil {
 		serial = controllerCard.GetSerialNumber()
@@ -189,7 +190,7 @@ func (m *InMemoryEntityManager) GetBootstrapData(lookup *service.EntityLookup, c
 }
 
 // SetStatus updates the status for each control card on the chassis.
-func (m *InMemoryEntityManager) SetStatus(req *bpb.ReportStatusRequest) error {
+func (m *InMemoryEntityManager) SetStatus(ctx context.Context, req *bpb.ReportStatusRequest) error {
 	if len(req.GetStates()) == 0 {
 		return status.Errorf(codes.InvalidArgument, "no control card or fixed chassis states provided")
 	}
@@ -209,7 +210,7 @@ func (m *InMemoryEntityManager) SetStatus(req *bpb.ReportStatusRequest) error {
 }
 
 // Sign unmarshals the SignedResponse bytes then generates a signature from its Ownership Certificate private key.
-func (m *InMemoryEntityManager) Sign(resp *bpb.GetBootstrapDataResponse, chassis *service.EntityLookup, controllerCard string) error {
+func (m *InMemoryEntityManager) Sign(ctx context.Context, resp *bpb.GetBootstrapDataResponse, chassis *service.EntityLookup, controllerCard string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// Check if security artifacts are provided for signing.

--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -42,7 +42,7 @@ import (
 type InMemoryEntityManager struct {
 	mu sync.Mutex
 	// inventory represents an organization's inventory of owned chassis.
-	chassisInventory map[service.EntityLookup]*epb.Chassis
+	chassisInventory []*epb.Chassis
 	// represents the current status of known control cards
 	controlCardStatuses map[string]bpb.ControlCardState_ControlCardStatus
 	// stores the default config such as security artifacts dir.
@@ -53,40 +53,35 @@ type InMemoryEntityManager struct {
 }
 
 // ResolveChassis returns an entity based on the provided lookup.
-// In cases when the serial for modular chassis is not set, it uses the controller card to find the chassis.
+// If a control card serial is provided, it also looks up chassis' by its control cards.
 func (m *InMemoryEntityManager) ResolveChassis(lookup *service.EntityLookup, ccSerial string) (*service.ChassisEntity, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	chassis, found := m.chassisInventory[*lookup]
-	if !found {
-		if lookup.SerialNumber == "" && ccSerial != "" {
-			ch, err := m.resolveChassisViaControllerCard(lookup, ccSerial)
-			if err != nil {
-				return nil, status.Errorf(codes.NotFound, "Could not find chassis with serial#: %s and manufacturer: %s and controller card %s",
-					lookup.SerialNumber, lookup.Manufacturer, ccSerial)
-			}
-			chassis = ch
-		} else {
-			return nil, status.Errorf(codes.NotFound, "Could not find chassis with serial#: %s and manufacturer: %s and controller card %s",
-				lookup.SerialNumber, lookup.Manufacturer, ccSerial)
-		}
+	chassis, err := m.lookupChassis(lookup, ccSerial)
+	if err != nil {
+		return nil, err
 	}
 	return &service.ChassisEntity{BootMode: chassis.GetBootMode()}, nil
 }
 
-// resolveChassisViaControllerCard resolves a chassis based on controller card serial.
-func (m *InMemoryEntityManager) resolveChassisViaControllerCard(lookup *service.EntityLookup, ccSerial string) (*epb.Chassis, error) {
-	for _, ch := range m.chassisInventory {
-		for _, c := range ch.GetControllerCards() {
-			if c.GetSerialNumber() == ccSerial {
-				if ch.Manufacturer != lookup.Manufacturer {
-					continue
+func (m *InMemoryEntityManager) lookupChassis(lookup *service.EntityLookup, ccSerial string) (*epb.Chassis, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Search for the chassis first.
+	for _, chassis := range m.chassisInventory {
+		if chassis.GetManufacturer() == lookup.Manufacturer {
+			if chassis.GetSerialNumber() == lookup.SerialNumber {
+				return chassis, nil
+			}
+			// While we're here, try looking up by control card.
+			if ccSerial != "" {
+				for _, c := range chassis.GetControllerCards() {
+					if c.GetSerialNumber() == ccSerial {
+						return chassis, nil
+					}
 				}
-				return ch, nil
 			}
 		}
 	}
-	return nil, status.Errorf(codes.NotFound, "could not find chassis for controller card with serial# %s", ccSerial)
+	return nil, status.Errorf(codes.NotFound, "could not find chassis for lookup %+v and control card %v", lookup, ccSerial)
 }
 
 func readOCConfig(path string) ([]byte, error) {
@@ -157,52 +152,19 @@ func populateBootConfig(conf *epb.BootConfig) (*bpb.BootConfig, error) {
 }
 
 // GetBootstrapData fetches and returns the bootstrap data response from the server.
-func (m *InMemoryEntityManager) GetBootstrapData(el *service.EntityLookup, controllerCard *bpb.ControlCard) (*bpb.BootstrapDataResponse, error) {
-	// First check if we are expecting this control card.
-	serial := ""
-	fixedChassis := false
-	if controllerCard == nil {
-		if el.SerialNumber == "" {
-			return nil, status.Errorf(codes.InvalidArgument, "chassis type (fixed/modular) can not be determined, either controller card or chassis serial must be set ")
-		}
-		fixedChassis = true
-		serial = el.SerialNumber
+func (m *InMemoryEntityManager) GetBootstrapData(lookup *service.EntityLookup, controllerCard *bpb.ControlCard) (*bpb.BootstrapDataResponse, error) {
+	serial := lookup.SerialNumber
+	if controllerCard != nil {
+		serial = controllerCard.GetSerialNumber()
 	}
-	if !fixedChassis {
-		serial = controllerCard.SerialNumber
-	}
-	// Check if the controller card and related chassis can be solved.
-	var chassis *epb.Chassis
-	found := false
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	log.Infof("Fetching data for controller card/chassis %v", serial)
-	if fixedChassis {
-		chassis, found = m.chassisInventory[*el]
-		if !found { // fixed chassis must have serial
-			return nil, status.Errorf(codes.NotFound, "could not find fixed chassis with serial#: %s and manufacturer: %s", chassis.SerialNumber, chassis.Manufacturer)
-		}
-	} else {
-		found = false
-	out:
-		for _, ch := range m.chassisInventory {
-			for _, c := range ch.GetControllerCards() {
-				if c.GetSerialNumber() == controllerCard.GetSerialNumber() && c.GetPartNumber() == controllerCard.PartNumber {
-					if ch.Manufacturer != el.Manufacturer {
-						continue
-					}
-					chassis = ch
-					found = true
-					break out
-				}
-			}
-		}
-		if !found {
-			return nil, status.Errorf(codes.NotFound, "could not find controller card with serial# %s", serial)
-		}
+	chassis, err := m.lookupChassis(lookup, controllerCard.GetSerialNumber())
+	if err != nil {
+		return nil, err
 	}
 	log.Infof("Control card located in inventory")
 	// TODO: for now add status for the controller card. We may need to move all runtime info to bootz service.
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.controlCardStatuses[serial] = bpb.ControlCardState_CONTROL_CARD_STATUS_UNSPECIFIED
 	bootCfg, err := populateBootConfig(chassis.GetConfig().GetBootConfig())
 	if err != nil {
@@ -304,28 +266,23 @@ func (m *InMemoryEntityManager) AddControlCard(serial string) *InMemoryEntityMan
 func (m *InMemoryEntityManager) AddChassis(bootMode bpb.BootMode, manufacturer string, serial string) *InMemoryEntityManager {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	l := service.EntityLookup{
-		Manufacturer: manufacturer,
-		SerialNumber: serial,
-	}
-	m.chassisInventory[l] = &epb.Chassis{
+	m.chassisInventory = append(m.chassisInventory, &epb.Chassis{
 		Manufacturer: manufacturer,
 		SerialNumber: serial,
 		BootMode:     bootMode,
-	}
+	})
 	log.Infof("Added %v chassis %v to server entity manager", manufacturer, serial)
 	return m
 }
 
 // GetChassisInventory returns the chassis inventory
-func (m *InMemoryEntityManager) GetChassisInventory() map[service.EntityLookup]*epb.Chassis {
+func (m *InMemoryEntityManager) GetChassisInventory() []*epb.Chassis {
 	return m.chassisInventory
 }
 
 // New returns a new in-memory entity manager.
 func New(chassisConfigFile string, artifacts *service.SecurityArtifacts) (*InMemoryEntityManager, error) {
 	newManager := &InMemoryEntityManager{
-		chassisInventory:    map[service.EntityLookup]*epb.Chassis{},
 		controlCardStatuses: map[string]bpb.ControlCardState_ControlCardStatus{},
 		defaults:            &epb.Options{GnsiGlobalConfig: &epb.GNSIConfig{}},
 		secArtifacts:        artifacts,
@@ -345,19 +302,13 @@ func New(chassisConfigFile string, artifacts *service.SecurityArtifacts) (*InMem
 		return nil, err
 	}
 	log.Infof("New entity manager is initialized successfully from chassis config file %s", chassisConfigFile)
-	for _, ch := range entities.Chassis {
-		lookup := service.EntityLookup{
-			Manufacturer: ch.GetManufacturer(),
-			SerialNumber: ch.GetSerialNumber(),
-		}
-		newManager.chassisInventory[lookup] = ch
-	}
+	newManager.chassisInventory = entities.Chassis
 	newManager.defaults = entities.GetOptions()
 	return newManager, nil
 }
 
 // ReplaceDevice replaces an existing chassis with a new chassis object.
-func (m *InMemoryEntityManager) ReplaceDevice(chassis *service.EntityLookup, newChassis *epb.Chassis) error {
+func (m *InMemoryEntityManager) ReplaceDevice(old *service.EntityLookup, new *epb.Chassis) error {
 	// Chassis: old device lookup, newChassis: new device
 
 	// todo: Validate before replace
@@ -365,50 +316,46 @@ func (m *InMemoryEntityManager) ReplaceDevice(chassis *service.EntityLookup, new
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	delete(m.chassisInventory, *chassis)
-
-	lookup := service.EntityLookup{
-		Manufacturer: newChassis.GetManufacturer(),
-		SerialNumber: newChassis.GetSerialNumber(),
+	for i, ch := range m.chassisInventory {
+		if ch.GetManufacturer() == old.Manufacturer && ch.GetSerialNumber() == old.SerialNumber {
+			m.chassisInventory[i] = new
+			return nil
+		}
 	}
 
-	m.chassisInventory[lookup] = newChassis
-
-	// This method will be able to return an error when validation is added.
-	return nil
+	return status.Errorf(codes.NotFound, "chassis %+v not found", *old)
 }
 
 // DeleteDevice removes the chassis at the provided lookup from the entitymanager.
 func (m *InMemoryEntityManager) DeleteDevice(chassis *service.EntityLookup) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	delete(m.chassisInventory, *chassis)
+	for i, ch := range m.chassisInventory {
+		if ch.GetManufacturer() == chassis.Manufacturer && ch.GetSerialNumber() == chassis.SerialNumber {
+			m.chassisInventory = append(m.chassisInventory[:i], m.chassisInventory[i+1:]...)
+		}
+	}
 }
 
 // GetDevice returns a copy of the chassis at the provided lookup.
 func (m *InMemoryEntityManager) GetDevice(chassis *service.EntityLookup) (*epb.Chassis, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if val, exists := m.chassisInventory[*chassis]; exists {
-		return proto.Clone(val).(*epb.Chassis), nil
+	ch, err := m.lookupChassis(chassis, "")
+	if err != nil {
+		return nil, err
 	}
-
-	return nil, status.Errorf(codes.NotFound, "Could not find chassis with serial#: %s and manufacturer: %s", chassis.SerialNumber, chassis.Manufacturer)
+	return proto.Clone(ch).(*epb.Chassis), nil
 }
 
 // GetAll returns a copy of the chassisInventory field.
-func (m *InMemoryEntityManager) GetAll() map[service.EntityLookup]*epb.Chassis {
+func (m *InMemoryEntityManager) GetAll() []*epb.Chassis {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	chassisMapClone := make(map[service.EntityLookup]*epb.Chassis)
+	chassisClone := make([]*epb.Chassis, len(m.chassisInventory))
 
-	for lookup, chassis := range m.chassisInventory {
-		chassisMapClone[lookup] = proto.Clone(chassis).(*epb.Chassis)
+	for i, chassis := range m.chassisInventory {
+		chassisClone[i] = proto.Clone(chassis).(*epb.Chassis)
 	}
 
-	return chassisMapClone
+	return chassisClone
 }

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -16,6 +16,7 @@ package entitymanager
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"os"
 	"testing"
@@ -212,6 +213,7 @@ func TestFetchOwnershipVoucher(t *testing.T) {
 }
 
 func TestResolveChassis(t *testing.T) {
+	ctx := context.Background()
 	tests := []struct {
 		desc    string
 		input   *service.EntityLookup
@@ -241,7 +243,7 @@ func TestResolveChassis(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			got, err := em.ResolveChassis(test.input, "")
+			got, err := em.ResolveChassis(ctx, test.input, "")
 			if (err != nil) != test.wantErr {
 				t.Fatalf("ResolveChassis(%v) err = %v, want %v", test.input, err, test.wantErr)
 			}
@@ -257,6 +259,7 @@ func TestSign(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to generate server artifacts: %v", err)
 	}
+	ctx := context.Background()
 	tests := []struct {
 		desc    string
 		chassis service.EntityLookup
@@ -294,7 +297,7 @@ func TestSign(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			err = em.Sign(test.resp, &test.chassis, test.serial)
+			err = em.Sign(ctx, test.resp, &test.chassis, test.serial)
 			if err != nil {
 				if test.wantErr {
 					t.Skip()
@@ -323,6 +326,7 @@ func TestSign(t *testing.T) {
 }
 
 func TestSetStatus(t *testing.T) {
+	ctx := context.Background()
 	tests := []struct {
 		desc    string
 		input   *bpb.ReportStatusRequest
@@ -367,7 +371,7 @@ func TestSetStatus(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			err := em.SetStatus(test.input)
+			err := em.SetStatus(ctx, test.input)
 			if (err != nil) != test.wantErr {
 				t.Errorf("SetStatus(%v) err = %v, want %v", test.input, err, test.wantErr)
 			}
@@ -380,6 +384,7 @@ func TestGetBootstrapData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to generate server artifacts: %v", err)
 	}
+	ctx := context.Background()
 	encodedServerTrustCert := base64.StdEncoding.EncodeToString(a.TrustAnchor.Raw)
 	chassis := epb.Chassis{
 		Name:                   "test",
@@ -540,7 +545,7 @@ func TestGetBootstrapData(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			got, err := em.GetBootstrapData(&service.EntityLookup{SerialNumber: test.chassisSerial, Manufacturer: test.chassisManufacturer}, test.input)
+			got, err := em.GetBootstrapData(ctx, &service.EntityLookup{SerialNumber: test.chassisSerial, Manufacturer: test.chassisManufacturer}, test.input)
 			if (err != nil) != test.wantErr {
 				t.Errorf("GetBootstrapData(%v) err = %v, want %v", test.input, err, test.wantErr)
 			}

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -84,15 +84,14 @@ func TestNew(t *testing.T) {
 	tests := []struct {
 		desc        string
 		chassisConf string
-		inventory   map[service.EntityLookup]*epb.Chassis
+		inventory   []*epb.Chassis
 		defaults    *epb.Options
 		wantErr     string
 	}{
 		{
 			desc:        "Successful new with file",
 			chassisConf: "../../testdata/inventory.prototxt",
-			inventory: map[service.EntityLookup]*epb.Chassis{{SerialNumber: chassis.SerialNumber,
-				Manufacturer: chassis.Manufacturer}: &chassis},
+			inventory:   []*epb.Chassis{&chassis},
 			defaults: &epb.Options{
 				Bootzserver: "bootzip:....",
 				ArtifactDir: "../../testdata/",
@@ -104,19 +103,19 @@ func TestNew(t *testing.T) {
 		{
 			desc:        "Unsuccessful new with wrong file",
 			chassisConf: "../../testdata/wrong_inventory.prototxt",
-			inventory:   map[service.EntityLookup]*epb.Chassis{},
+			inventory:   []*epb.Chassis{},
 			wantErr:     "proto:",
 		},
 		{
 			desc:        "Unsuccessful new with wrong file path",
 			chassisConf: "not/valid/path",
-			inventory:   map[service.EntityLookup]*epb.Chassis{},
+			inventory:   []*epb.Chassis{},
 			wantErr:     "no such file or directory",
 		},
 		{
 			desc:        "Successful new with empty file path",
 			chassisConf: "",
-			inventory:   map[service.EntityLookup]*epb.Chassis{},
+			inventory:   nil,
 			defaults:    &epb.Options{GnsiGlobalConfig: &epb.GNSIConfig{}},
 		},
 	}
@@ -197,8 +196,7 @@ func TestFetchOwnershipVoucher(t *testing.T) {
 	}}
 
 	em, _ := New("", a)
-
-	em.chassisInventory[service.EntityLookup{Manufacturer: "Cisco", SerialNumber: "123"}] = &chassis
+	em.chassisInventory = []*epb.Chassis{&chassis}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -538,8 +536,7 @@ func TestGetBootstrapData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create entitymanager: %v", err)
 	}
-
-	em.chassisInventory[service.EntityLookup{Manufacturer: "Cisco", SerialNumber: "123"}] = &chassis
+	em.chassisInventory = []*epb.Chassis{&chassis}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
@@ -638,57 +635,53 @@ func TestLoadConfig(t *testing.T) {
 
 func TestGetDevice(t *testing.T) {
 	tests := []struct {
-		name             string
-		chassisInventory *epb.Entities
-		wantErr          string
+		name        string
+		inventory   []*epb.Chassis
+		lookup      *service.EntityLookup
+		wantChassis *epb.Chassis
+		wantErr     string
 	}{
 		{
-			name: "Successfully GetDevice",
-			chassisInventory: &epb.Entities{
-				Chassis: []*epb.Chassis{
-					{
-						SerialNumber: "1234",
-						Manufacturer: "cisco",
-					},
+			name:   "Successfully GetDevice",
+			lookup: &service.EntityLookup{SerialNumber: "1234", Manufacturer: "cisco"},
+			inventory: []*epb.Chassis{
+				{
+					SerialNumber: "1234",
+					Manufacturer: "cisco",
 				},
+			},
+			wantChassis: &epb.Chassis{
+				SerialNumber: "1234",
+				Manufacturer: "cisco",
 			},
 			wantErr: "",
 		},
 		{
-			name: "Unsuccessfully GetDevice",
-			chassisInventory: &epb.Entities{
-				Chassis: []*epb.Chassis{
-					{
-						PartNumber:   "5678",
-						Manufacturer: "sysco",
-					},
+			name:   "Unsuccessfully GetDevice",
+			lookup: &service.EntityLookup{SerialNumber: "1234", Manufacturer: "cisco"},
+			inventory: []*epb.Chassis{
+				{
+					SerialNumber: "5678",
+					Manufacturer: "sysco",
 				},
 			},
-			wantErr: "Could not find chassis with serial#: 1234 and manufacturer: cisco",
+			wantChassis: nil,
+			wantErr:     "could not find chassis for lookup",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configsMap := make(map[service.EntityLookup]*epb.Chassis)
-			for _, chassis := range tt.chassisInventory.Chassis {
-				configsMap[service.EntityLookup{SerialNumber: chassis.SerialNumber, Manufacturer: chassis.Manufacturer}] = chassis
-			}
-
 			em := InMemoryEntityManager{
-				chassisInventory: configsMap,
+				chassisInventory: tt.inventory,
 			}
 
-			lookup := service.EntityLookup{SerialNumber: "1234", Manufacturer: "cisco"}
-
-			want, exists := em.chassisInventory[lookup]
-
-			received, err := em.GetDevice(&lookup)
+			got, err := em.GetDevice(tt.lookup)
 
 			if s := errdiff.Check(err, tt.wantErr); s != "" {
 				t.Errorf("Expected error %s, but got error %v", tt.wantErr, err)
-			} else if exists && !(proto.Equal(want, received)) {
-				t.Errorf("Result of GetDevice does not match expected\nwant:\n\t%s\nactual:\n\t%s", want, received)
+			} else if !(proto.Equal(tt.wantChassis, got)) {
+				t.Errorf("Result of GetDevice does not match expected\nwant:\n\t%s\nactual:\n\t%s", tt.wantChassis, got)
 			}
 		})
 	}
@@ -696,21 +689,19 @@ func TestGetDevice(t *testing.T) {
 
 func TestGetAll(t *testing.T) {
 	tests := []struct {
-		chassisInventory *epb.Entities
-		name             string
+		inventory []*epb.Chassis
+		name      string
 	}{
 		{
 			name: "Successful GetAll",
-			chassisInventory: &epb.Entities{
-				Chassis: []*epb.Chassis{
-					{
-						SerialNumber: "1234",
-						Manufacturer: "cisco",
-					},
-					{
-						SerialNumber: "5678",
-						Manufacturer: "cisco",
-					},
+			inventory: []*epb.Chassis{
+				{
+					SerialNumber: "1234",
+					Manufacturer: "cisco",
+				},
+				{
+					SerialNumber: "5678",
+					Manufacturer: "cisco",
 				},
 			},
 		},
@@ -718,18 +709,13 @@ func TestGetAll(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configsMap := make(map[service.EntityLookup]*epb.Chassis)
-			for _, chassis := range tt.chassisInventory.Chassis {
-				configsMap[service.EntityLookup{SerialNumber: chassis.SerialNumber, Manufacturer: chassis.Manufacturer}] = chassis
-			}
-
 			em := InMemoryEntityManager{
-				chassisInventory: configsMap,
+				chassisInventory: tt.inventory,
 			}
-			received := em.GetAll()
+			got := em.GetAll()
 
-			if !(cmp.Equal(configsMap, received, protocmp.Transform())) {
-				t.Errorf("Result of GetDevice does not match expected\nwant:\n\t%s\nactual:\n\t%s", configsMap, received)
+			if !(cmp.Equal(tt.inventory, got, protocmp.Transform())) {
+				t.Errorf("Result of GetDevice does not match expected\nwant:\n\t%s\nactual:\n\t%s", tt.inventory, got)
 			}
 		})
 	}
@@ -737,62 +723,49 @@ func TestGetAll(t *testing.T) {
 
 func TestReplaceDevice(t *testing.T) {
 	tests := []struct {
-		chassisInventory     *epb.Entities
-		wantChassisInventory *epb.Entities
-		name                 string
-		wantErr              string
+		inventory     []*epb.Chassis
+		wantInventory []*epb.Chassis
+		lookup        *service.EntityLookup
+		name          string
+		newChassis    *epb.Chassis
+		wantErr       string
 	}{
 		{
 			name: "Successfully ReplaceDevice",
-			chassisInventory: &epb.Entities{
-				Chassis: []*epb.Chassis{
-					{
-						SerialNumber: "1234",
-						Manufacturer: "cisco",
-					},
+			inventory: []*epb.Chassis{
+				{
+					SerialNumber: "1234",
+					Manufacturer: "cisco",
 				},
 			},
-			wantChassisInventory: &epb.Entities{
-				Chassis: []*epb.Chassis{
-					{
-						SerialNumber: "5678",
-						Manufacturer: "cisco",
-					},
+			lookup: &service.EntityLookup{SerialNumber: "1234", Manufacturer: "cisco"},
+			newChassis: &epb.Chassis{
+				SerialNumber: "5678",
+				Manufacturer: "cisco",
+			},
+			wantInventory: []*epb.Chassis{
+				{
+					SerialNumber: "5678",
+					Manufacturer: "cisco",
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configsMap := make(map[service.EntityLookup]*epb.Chassis)
-			for _, chassis := range tt.chassisInventory.Chassis {
-				configsMap[service.EntityLookup{SerialNumber: chassis.SerialNumber, Manufacturer: chassis.Manufacturer}] = chassis
-			}
-
-			want := make(map[service.EntityLookup]*epb.Chassis)
-			for _, chassis := range tt.wantChassisInventory.Chassis {
-				want[service.EntityLookup{SerialNumber: chassis.SerialNumber, Manufacturer: chassis.Manufacturer}] = chassis
-			}
-
 			em := InMemoryEntityManager{
-				chassisInventory: configsMap,
+				chassisInventory: tt.inventory,
 			}
 
-			newObj := &epb.Chassis{
-				SerialNumber: "5678",
-				Manufacturer: "cisco",
-			}
-
-			err := em.ReplaceDevice(&service.EntityLookup{SerialNumber: "1234", Manufacturer: "cisco"}, newObj)
-
-			received := em.chassisInventory
+			err := em.ReplaceDevice(tt.lookup, tt.newChassis)
+			got := em.chassisInventory
 
 			// todo: This test will require error checking after ValidateConfig is implemented.
 
 			if s := errdiff.Check(err, tt.wantErr); s != "" {
 				t.Errorf("Expected error %s, but got error %v", tt.wantErr, err)
-			} else if !(cmp.Equal(want, received, protocmp.Transform())) {
-				t.Errorf("Result of ReplaceDevice does not match expected\nwant:\n\t%s\nactual:\n\t%s", want, received)
+			} else if !(cmp.Equal(tt.inventory, got, protocmp.Transform())) {
+				t.Errorf("Result of ReplaceDevice does not match expected\nwant:\n\t%s\nactual:\n\t%s", tt.inventory, got)
 			}
 		})
 	}
@@ -800,62 +773,50 @@ func TestReplaceDevice(t *testing.T) {
 
 func TestDeleteDevice(t *testing.T) {
 	tests := []struct {
-		chassisInventory     *epb.Entities
-		wantChassisInventory *epb.Entities
-		name                 string
+		inventory     []*epb.Chassis
+		wantInventory []*epb.Chassis
+		lookup        *service.EntityLookup
+		name          string
 	}{
 		{
 			name: "Successfully DeleteDevice",
-			chassisInventory: &epb.Entities{
-				Chassis: []*epb.Chassis{
-					{
-						SerialNumber: "1234",
-						Manufacturer: "cisco",
-					},
+			inventory: []*epb.Chassis{
+				{
+					SerialNumber: "1234",
+					Manufacturer: "cisco",
 				},
 			},
-			wantChassisInventory: &epb.Entities{},
+			lookup:        &service.EntityLookup{SerialNumber: "1234", Manufacturer: "cisco"},
+			wantInventory: []*epb.Chassis{},
 		},
 		{
 			name: "DeleteDevice nonexistent",
-			chassisInventory: &epb.Entities{
-				Chassis: []*epb.Chassis{
-					{
-						SerialNumber: "5678",
-						Manufacturer: "cisco",
-					},
+			inventory: []*epb.Chassis{
+				{
+					SerialNumber: "5678",
+					Manufacturer: "cisco",
 				},
 			},
-			wantChassisInventory: &epb.Entities{
-				Chassis: []*epb.Chassis{
-					{
-						SerialNumber: "5678",
-						Manufacturer: "cisco",
-					},
+			lookup: &service.EntityLookup{SerialNumber: "1234", Manufacturer: "cisco"},
+			wantInventory: []*epb.Chassis{
+				{
+					SerialNumber: "5678",
+					Manufacturer: "cisco",
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configsMap := make(map[service.EntityLookup]*epb.Chassis)
-			for _, chassis := range tt.chassisInventory.Chassis {
-				configsMap[service.EntityLookup{SerialNumber: chassis.SerialNumber, Manufacturer: chassis.Manufacturer}] = chassis
-			}
-
-			want := make(map[service.EntityLookup]*epb.Chassis)
-			for _, chassis := range tt.wantChassisInventory.Chassis {
-				want[service.EntityLookup{SerialNumber: chassis.SerialNumber, Manufacturer: chassis.Manufacturer}] = chassis
-			}
 
 			em := InMemoryEntityManager{
-				chassisInventory: configsMap,
+				chassisInventory: tt.inventory,
 			}
 
-			em.DeleteDevice(&service.EntityLookup{SerialNumber: "1234", Manufacturer: "cisco"})
+			em.DeleteDevice(tt.lookup)
 
-			if !(cmp.Equal(want, em.chassisInventory, protocmp.Transform())) {
-				t.Errorf("Result of DeleteDevice does not match expected\nwant:\n\t%s\nactual:\n\t%s", want, em.chassisInventory)
+			if !(cmp.Equal(tt.wantInventory, em.chassisInventory, protocmp.Transform())) {
+				t.Errorf("Result of DeleteDevice does not match expected\nwant:\n\t%s\nactual:\n\t%s", tt.wantInventory, em.chassisInventory)
 			}
 		})
 	}


### PR DESCRIPTION
That map implementation limits us to how we look up entities and is hard to extend. This changes the inventory to just be a simple slice of entities.