### PR TITLE
Include resolved bpb.Chassis in GetBootstrapData method.

### DIFF
--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -155,7 +155,7 @@ func populateBootConfig(conf *epb.BootConfig) (*bpb.BootConfig, error) {
 }
 
 // GetBootstrapData fetches and returns the bootstrap data response from the server.
-func (m *InMemoryEntityManager) GetBootstrapData(ctx context.Context, lookup *service.EntityLookup, controllerCard *bpb.ControlCard) (*bpb.BootstrapDataResponse, error) {
+func (m *InMemoryEntityManager) GetBootstrapData(ctx context.Context, ch *bpb.Chassis, lookup *service.EntityLookup, controllerCard *bpb.ControlCard) (*bpb.BootstrapDataResponse, error) {
 	serial := lookup.SerialNumber
 	if controllerCard != nil {
 		serial = controllerCard.GetSerialNumber()

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -545,7 +545,8 @@ func TestGetBootstrapData(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			got, err := em.GetBootstrapData(ctx, &service.EntityLookup{SerialNumber: test.chassisSerial, Manufacturer: test.chassisManufacturer}, test.input)
+			//TODO(https://github.com/openconfig/bootz/issues/105): Populate bpb.Chassis once epb.Chassis has been de-duplicated.
+			got, err := em.GetBootstrapData(ctx, &bpb.Chassis{}, &service.EntityLookup{SerialNumber: test.chassisSerial, Manufacturer: test.chassisManufacturer}, test.input)
 			if (err != nil) != test.wantErr {
 				t.Errorf("GetBootstrapData(%v) err = %v, want %v", test.input, err, test.wantErr)
 			}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -70,7 +70,7 @@ type EntityLookup struct {
 // EntityManager maintains the entities and their states.
 type EntityManager interface {
 	ResolveChassis(context.Context, *EntityLookup, string) (*bpb.Chassis, error)
-	GetBootstrapData(context.Context, *EntityLookup, *bpb.ControlCard) (*bpb.BootstrapDataResponse, error)
+	GetBootstrapData(context.Context, *bpb.Chassis, *EntityLookup, *bpb.ControlCard) (*bpb.BootstrapDataResponse, error)
 	SetStatus(context.Context, *bpb.ReportStatusRequest) error
 	Sign(context.Context, *bpb.GetBootstrapDataResponse, *EntityLookup, string) error
 }
@@ -124,7 +124,7 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bpb.GetBootstrapDat
 	log.Infof("=============================================================================")
 	var responses []*bpb.BootstrapDataResponse
 	for _, v := range chassisDesc.GetControlCards() {
-		bootdata, err := s.em.GetBootstrapData(ctx, lookup, v)
+		bootdata, err := s.em.GetBootstrapData(ctx, chassis, lookup, v)
 		if err != nil {
 			errs.Add(err)
 			log.Infof("Error occurred while retrieving data for Serial Number %v", v.SerialNumber)
@@ -132,7 +132,7 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bpb.GetBootstrapDat
 		responses = append(responses, bootdata)
 	}
 	if fixedChasis {
-		bootdata, err := s.em.GetBootstrapData(ctx, lookup, nil)
+		bootdata, err := s.em.GetBootstrapData(ctx, chassis, lookup, nil)
 		if err != nil {
 			errs.Add(err)
 			log.Infof("Error occurred while retrieving data for fixed chassis with serail number %v", lookup.SerialNumber)


### PR DESCRIPTION
This field is not currently used in the open source implementation but will be once we migrate to using a single proto message in https://github.com/openconfig/bootz/issues/105. 

Additionally, the open source implementation does not need this field yet but the internal one does.