### PR TITLE
Add a new helper function "buildEntityLookup"

### DIFF
--- a/server/service/service.go
+++ b/server/service/service.go
@@ -58,13 +58,54 @@ type SecurityArtifacts struct {
 	TLSKeypair *tls.Certificate
 }
 
-// EntityLookup provides a way to resolve chassis and control cards
-// in the EntityManager.
+// EntityLookup is used to resolve the fields of an active control card to a chassis.
+// For fixed form factor devices, the active control card is the chassis itself.
 type EntityLookup struct {
+	// The manufacturer of this control card or chassis.
 	Manufacturer string
+	// The serial number of this control card or chassis.
 	SerialNumber string
-	PartNumber   string
-	IPAddress    string
+	// The hardware model/part number of this control card or chassis.
+	PartNumber string
+	// The reported IP address of the management interface for this control
+	// card or chassis.
+	IPAddress string
+	// Whether this chassis appears to be a modular device.
+	Modular bool
+}
+
+// buildEntityLookup constructs an EntityLookup object from a bootstrap request.
+func buildEntityLookup(ctx context.Context, req *bpb.GetBootstrapDataRequest) (*EntityLookup, error) {
+	peerAddr, err := peerAddressFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	activeControlCardSerial := req.GetControlCardState().GetSerialNumber()
+	var partNumber string
+	var modular bool
+	if len(req.GetChassisDescriptor().GetControlCards()) == 0 {
+		modular = false
+		partNumber = req.GetChassisDescriptor().GetPartNumber()
+	} else {
+		modular = true
+		for _, card := range req.GetChassisDescriptor().GetControlCards() {
+			if card.GetSerialNumber() == activeControlCardSerial {
+				partNumber = card.GetPartNumber()
+				break
+			}
+		}
+	}
+	if partNumber == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "active control card with serial %v not found in chassis descriptor", activeControlCardSerial)
+	}
+	lookup := &EntityLookup{
+		Manufacturer: req.GetChassisDescriptor().GetManufacturer(),
+		SerialNumber: activeControlCardSerial,
+		PartNumber:   partNumber,
+		IPAddress:    peerAddr,
+		Modular:      modular,
+	}
+	return lookup, nil
 }
 
 // EntityManager maintains the entities and their states.

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -81,6 +81,9 @@ func buildEntityLookup(ctx context.Context, req *bpb.GetBootstrapDataRequest) (*
 		return nil, err
 	}
 	activeControlCardSerial := req.GetControlCardState().GetSerialNumber()
+	if activeControlCardSerial == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "no active control card serial provided")
+	}
 	var partNumber string
 	var modular bool
 	if len(req.GetChassisDescriptor().GetControlCards()) == 0 {

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -123,6 +123,18 @@ func TestBuildEntityLookup(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Fixed form factor does not set active control card",
+			ctx:  peerAddressContext(t, "1.1.1.1"),
+			req: &bpb.GetBootstrapDataRequest{
+				ChassisDescriptor: &bpb.ChassisDescriptor{
+					Manufacturer: "Cisco",
+					SerialNumber: "1234",
+					PartNumber:   "ABC",
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name:    "No address in context",
 			ctx:     context.Background(),
 			wantErr: true,

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -1,0 +1,146 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package service
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/peer"
+
+	bpb "github.com/openconfig/bootz/proto/bootz"
+)
+
+func peerAddressContext(t *testing.T, address string) context.Context {
+	t.Helper()
+	return peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{
+			IP: net.ParseIP(address),
+		},
+	})
+}
+
+func TestBuildEntityLookup(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		req     *bpb.GetBootstrapDataRequest
+		want    *EntityLookup
+		wantErr bool
+	}{
+		{
+			name: "Successful fixed-form factor",
+			ctx:  peerAddressContext(t, "1.1.1.1"),
+			req: &bpb.GetBootstrapDataRequest{
+				ChassisDescriptor: &bpb.ChassisDescriptor{
+					Manufacturer: "Cisco",
+					SerialNumber: "1234",
+					PartNumber:   "ABC",
+				},
+				ControlCardState: &bpb.ControlCardState{
+					SerialNumber: "1234",
+				},
+			},
+			want: &EntityLookup{
+				Manufacturer: "Cisco",
+				SerialNumber: "1234",
+				PartNumber:   "ABC",
+				IPAddress:    "1.1.1.1",
+				Modular:      false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Successful modular device",
+			ctx:  peerAddressContext(t, "1.1.1.1"),
+			req: &bpb.GetBootstrapDataRequest{
+				ChassisDescriptor: &bpb.ChassisDescriptor{
+					Manufacturer: "Cisco",
+					ControlCards: []*bpb.ControlCard{
+						{
+							SerialNumber: "1234a",
+							PartNumber:   "ABCa",
+						},
+					},
+				},
+				ControlCardState: &bpb.ControlCardState{
+					SerialNumber: "1234a",
+				},
+			},
+			want: &EntityLookup{
+				Manufacturer: "Cisco",
+				SerialNumber: "1234a",
+				PartNumber:   "ABCa",
+				IPAddress:    "1.1.1.1",
+				Modular:      true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Modular chassis descriptor contains wrong control card",
+			ctx:  peerAddressContext(t, "1.1.1.1"),
+			req: &bpb.GetBootstrapDataRequest{
+				ChassisDescriptor: &bpb.ChassisDescriptor{
+					Manufacturer: "Cisco",
+					ControlCards: []*bpb.ControlCard{
+						{
+							SerialNumber: "1234b",
+							PartNumber:   "ABCb",
+						},
+					},
+				},
+				ControlCardState: &bpb.ControlCardState{
+					SerialNumber: "1234a",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Fixed form factor device has no part number",
+			ctx:  peerAddressContext(t, "1.1.1.1"),
+			req: &bpb.GetBootstrapDataRequest{
+				ChassisDescriptor: &bpb.ChassisDescriptor{
+					Manufacturer: "Cisco",
+					SerialNumber: "1234",
+				},
+				ControlCardState: &bpb.ControlCardState{
+					SerialNumber: "12344",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "No address in context",
+			ctx:     context.Background(),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildEntityLookup(tc.ctx, tc.req)
+			if err != nil {
+				if tc.wantErr {
+					return
+				}
+				t.Fatalf("buildEntityLookup err = %v, want nil", err)
+			}
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("buildEntityLookup diff = %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently there's no consistent way of looking up modular or fixed form factor chassis'. This is the first step in having a single entity lookup builder.

Note: This function isn't used yet, this will be plugged into service.go in a future PR. 