### PR TITLE
Allow SetStatus() to be called on unseen control cards

### DIFF
--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -165,10 +165,6 @@ func (m *InMemoryEntityManager) GetBootstrapData(ctx context.Context, ch *bpb.Ch
 		return nil, err
 	}
 	log.Infof("Control card located in inventory")
-	// TODO: for now add status for the controller card. We may need to move all runtime info to bootz service.
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.controlCardStatuses[serial] = bpb.ControlCardState_CONTROL_CARD_STATUS_UNSPECIFIED
 	bootCfg, err := populateBootConfig(chassis.GetConfig().GetBootConfig())
 	if err != nil {
 		return nil, err
@@ -203,7 +199,8 @@ func (m *InMemoryEntityManager) SetStatus(ctx context.Context, req *bpb.ReportSt
 	for _, c := range req.GetStates() {
 		previousStatus, ok := m.controlCardStatuses[c.GetSerialNumber()]
 		if !ok {
-			return status.Errorf(codes.NotFound, "control card %v not found in inventory", c.GetSerialNumber())
+			previousStatus = bpb.ControlCardState_CONTROL_CARD_STATUS_UNSPECIFIED
+			m.controlCardStatuses[c.GetSerialNumber()] = previousStatus
 		}
 		log.Infof("control card %v changed status from %v to %v", c.GetSerialNumber(), previousStatus, c.GetStatus())
 		m.controlCardStatuses[c.GetSerialNumber()] = c.GetStatus()

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -339,7 +339,7 @@ func TestSetStatus(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
-		desc: "Control card initialized",
+		desc: "Known control card initialized",
 		input: &bpb.ReportStatusRequest{
 			Status:        bpb.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
 			StatusMessage: "Bootstrap status succeeded",
@@ -352,18 +352,18 @@ func TestSetStatus(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
-		desc: "Unknown control card",
+		desc: "Unseen control card initialized",
 		input: &bpb.ReportStatusRequest{
 			Status:        bpb.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
 			StatusMessage: "Bootstrap status succeeded",
 			States: []*bpb.ControlCardState{
 				{
-					SerialNumber: "123C",
+					SerialNumber: "123B",
 					Status:       *bpb.ControlCardState_CONTROL_CARD_STATUS_INITIALIZED.Enum(),
 				},
 			},
 		},
-		wantErr: true,
+		wantErr: false,
 	},
 	}
 	em, _ := New("", nil)


### PR DESCRIPTION
This removes the need for GetBootstrapData() to manually set the control card's status to UNSPECIFIED as it is already the default value.