### PR TITLE
Pass the resolved Chassis object to Sign().

### DIFF
--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -221,7 +221,7 @@ func (m *InMemoryEntityManager) SetStatus(ctx context.Context, req *bpb.ReportSt
 }
 
 // Sign unmarshals the SignedResponse bytes then generates a signature from its Ownership Certificate private key.
-func (m *InMemoryEntityManager) Sign(ctx context.Context, resp *bpb.GetBootstrapDataResponse, chassis *service.EntityLookup, controllerCard string) error {
+func (m *InMemoryEntityManager) Sign(ctx context.Context, resp *bpb.GetBootstrapDataResponse, chassis *service.Chassis, controllerCard string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// Check if security artifacts are provided for signing.

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -294,16 +294,23 @@ func TestSign(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		desc    string
-		chassis service.EntityLookup
+		chassis service.Chassis
 		serial  string
 		resp    *bpb.GetBootstrapDataResponse
 		wantOC  bool
 		wantErr bool
 	}{{
 		desc: "Success",
-		chassis: service.EntityLookup{
+		chassis: service.Chassis{
 			Manufacturer: "Cisco",
-			SerialNumber: "123",
+			Serial:       "123",
+			ControlCards: []*service.ControlCard{
+				{
+					Serial:       "123A",
+					Manufacturer: "Cisco",
+					PartNumber:   "123A",
+				},
+			},
 		},
 		serial: "123A",
 		resp: &bpb.GetBootstrapDataResponse{

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -149,7 +149,7 @@ type EntityManager interface {
 	ResolveChassis(context.Context, *EntityLookup, string) (*Chassis, error)
 	GetBootstrapData(context.Context, *Chassis, string) (*bpb.BootstrapDataResponse, error)
 	SetStatus(context.Context, *bpb.ReportStatusRequest) error
-	Sign(context.Context, *bpb.GetBootstrapDataResponse, *EntityLookup, string) error
+	Sign(context.Context, *bpb.GetBootstrapDataResponse, *Chassis, string) error
 }
 
 // Service represents the server and entity manager.
@@ -247,7 +247,7 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bpb.GetBootstrapDat
 		log.Infof("=============================================================================")
 		log.Infof("====================== Signing the response with nonce ======================")
 		log.Infof("=============================================================================")
-		if err := s.em.Sign(ctx, resp, lookup, req.GetControlCardState().GetSerialNumber()); err != nil {
+		if err := s.em.Sign(ctx, resp, chassis, req.GetControlCardState().GetSerialNumber()); err != nil {
 			return nil, err
 		}
 		log.Infof("Signed with nonce")


### PR DESCRIPTION
Similar to https://github.com/openconfig/bootz/pull/118, we now rely on the resolved Chassis object instead of the lookup object in EntityManager.