### PR TITLE
Add a TODO to cleanup the skip_enrollment flag

### DIFF
--- a/server/service/service.go
+++ b/server/service/service.go
@@ -102,6 +102,7 @@ type Chassis struct {
 	FabricName string
 	// Indicates whether enrollment will be skipped later in the install process.
 	// Some parts of boot config may be different depending on the value of this flag.
+	// TODO(b/354602807): Clean up this flag when not required anymore.
 	SkipEnrollment bool
 }
 


### PR DESCRIPTION
Add a TODO to cleanup testing flag which is only required during vendor integrations.