### PR TITLE
Add dynamic configuration to a `BootConfig` message.

### DIFF
--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -318,8 +318,8 @@ message BootConfig {
   // configuration such as that applied by a gnmi.Set RPC call.
   //
   // These fields MUST only be used in the context of a BootstrapDataResponse
-  // and are not valid when a `BootConfig` is updated after device initialisation,
-  // for example through `gnoi.bootconfig.SetBootConfig`.
+  // and are not valid when a `BootConfig` is updated after device
+  // initialisation, for example through `gnoi.bootconfig.SetBootConfig`.
   //
   // Native format vendor configuration.
   bytes dynamic_vendor_config = 5;

--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -305,6 +305,17 @@ message BootConfig {
   // configuration (e.g., feature flags, or vendor-specific hardware knobs).
   google.protobuf.Struct metadata = 1;
 
+  // Fields to store the configuration that is expected of a device at boot
+  // time. In all cases, the configuration used on the system is computed based
+  // on the union of vendor_config + oc_config + dynamic_vendor_config +
+  // dynamic_oc_config. The union should be performed according to the same
+  // rules as `union_replace` in gNMI.
+  //
+  // Note, the dynamic_* fields MUST only be considered in the context of a
+  // `BootstrapDataResponse` and are NOT valid when a `BootConfig` is updated
+  // after device bootstrapping/initialisation -- for example, through
+  // `gnoi.bootconfig.SetBootConfig`.
+  // 
   // vendor_config and oc_config specify boot configuration that is considered
   // immutable per the specification described in github.com/openconfig/bootz.
   // 
@@ -317,9 +328,8 @@ message BootConfig {
   // that is required at boot time, but can be overwritten by dynamic
   // configuration such as that applied by a gnmi.Set RPC call.
   //
-  // These fields MUST only be used in the context of a BootstrapDataResponse
-  // and are not valid when a `BootConfig` is updated after device
-  // initialisation, for example through `gnoi.bootconfig.SetBootConfig`.
+  // As per the above comment dynamic_vendor_config and dynamic_oc_config
+  // are ONLY valid in the context of `BootstrapDataResponse`.
   //
   // Native format vendor configuration.
   bytes dynamic_vendor_config = 5;

--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -314,7 +314,9 @@ message BootConfig {
   // Note, the dynamic_* fields MUST only be considered in the context of a
   // `BootstrapDataResponse` and are NOT valid when a `BootConfig` is updated
   // after device bootstrapping/initialisation -- for example, through
-  // `gnoi.bootconfig.SetBootConfig`.
+  // `gnoi.bootconfig.SetBootConfig`. In the case that these fields are
+  // populated in the `SetBootConfig` RPC, an error with the code
+  // `InvalidArgument` MUST be returned.
   // 
   // vendor_config and oc_config specify boot configuration that is considered
   // immutable per the specification described in github.com/openconfig/bootz.

--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -304,10 +304,24 @@ message BootConfig {
   // Proprietary key-value parameters that are required as part of boot
   // configuration (e.g., feature flags, or vendor-specific hardware knobs).
   google.protobuf.Struct metadata = 1;
+
+  // vendor_config and oc_config specify boot configuration that is considered
+  // immutable per the specification described in github.com/openconfig/bootz.
+  // 
   // Native format vendor configuration.
   bytes vendor_config = 2;
   // JSON rendered OC configuration.
   bytes oc_config = 3;
+
+  // dynamic_vendor_config and dynamic_oc_config specify boot configuration
+  // that is required at boot time, but can be overwritten by dynamic
+  // configuration such as that applied by a gnmi.Set RPC call.
+  //
+  // Native format vendor configuration.
+  bytes dynamic_vendor_config = 5;
+  // JSON rendered OC configuration.
+  bytes dynamic_oc_config = 6;
+
   // Bootloader key-value parameters that are required as part of boot
   // configuration.
   google.protobuf.Struct bootloader_config = 4;

--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -317,6 +317,10 @@ message BootConfig {
   // that is required at boot time, but can be overwritten by dynamic
   // configuration such as that applied by a gnmi.Set RPC call.
   //
+  // These fields MUST only be used in the context of a BootstrapDataResponse
+  // and are not valid when a `BootConfig` is updated after device initialisation,
+  // for example through `gnoi.bootconfig.SetBootConfig`.
+  //
   // Native format vendor configuration.
   bytes dynamic_vendor_config = 5;
   // JSON rendered OC configuration.


### PR DESCRIPTION
```
 * (M) proto/bootz.proto
   - In some cases, the configuration that needs to be applied
     through the boot process is not immutable per the current
     specification of the bootz process. This change adds the
     ability to provide dynamic configuration during an initial
     boot that may be overwritten later in the process.
```

## Change justification

Consider the scenario that a device is being boostrapped from factory-reset (zero-ised) state. In such cases, the bootz server provides a `BootConfig` which contains the minimum manageable state of the device. This may include some configuration such as ACLs that protect the control-plane of the device. Currently, such an ACL becomes immutable, which means that to change it, a client needs to know that it must also call `gnoi.bootconfig.SetBootConfig` as well as `gnmi.Set` to change some configuration of the device. This is a workable solution -- but adds some complexity to the calling client system.

An alternative design -- proposed herein -- is to allow two different types of configuration to be applied during the initial bootstrap operation:

 1. immutable (precendence 10) boot configuration -- which contains the static minimum-manageable-state configuration of the device.
 1. dynamic (precedence 100) configuration -- which contains dynamic config that is required during the initial bootstrap.

This simplifies the overall operation for configuration management, since configuration that is truly immutable boot configuration still remains within the bootz namespace, and configuration that is required at boot time but is dynamic remains within a namespace where it can be mutated.

## Alternate designs

There are alternate designs that could be considered here.

### Configuration management system calls `gnoi.bootconfig.SetBootConfig` as well as `gnmi.Set`.

Pros:
 - Requires no changes to the existing RPCs that are available from a network device.

Cons:
 - Confuses the concept of the boot configuration, which today is considered immutable.
 - Requires the configuration management system to have permissions to update the bootconfig -- which affects the device's base management reachability.


### (Proposed) Allow for initial dynamic configuration to be supplied through `bootz`.

Pros:
 - Clearly maintains the idea of an immutable boot configuration, and a dynamic configuration that has one RPC that can be used to manage it.
 - Allows the immutable minimum-manageable configuration to be kept static -- via an RPC that can have more constrained security policies reflected against it.

Cons:
 - Requires caution to ensure that the dynamic configuration is well-understood. In the factory-fresh bootstrap case it is clearer -- since there is no dynamic configuration. However, in future cases `gnoi.bootconfig.SetBootConfig` can be called, in these cases, the `dynamic_*_config` fields must not be specified otherwise this will override the dynamic configuration.
