### PR TITLE
Clients should not present any TLS certificate in the BootstrapStream TLS handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,9 +402,7 @@ the ownership voucher and ownership certificate.
 2. Bootstrapping Service
     1. Device initiates a gRPC connection to the bootz-server whose address was
         obtained from the DHCP server.
-    2. The TLS connection may use any certificate it has available. This can
-        be a self-signed certificate as the cert is only used to encrypt the
-        connection.
+    2. The device **must not** present a client certificate in the TLS handshake.
     4. The responses from the bootz-server are signed by ownership-certificate.
         The device validates the ownership-voucher, which authenticates the
         ownership-certificate. The device verifies the signature of the message


### PR DESCRIPTION
This PR introduces a new requirement to BootstrapStream clients which is that they should not present any client certificate during the initial TLS handshake. The reasons for this are:

- It's ignored anyway.
- If we can enforce this, Bootz server will be able to use the TLS ClientAuth option "VerifyClientCertIfGiven": https://pkg.go.dev/crypto/tls#ClientAuthType. With this option, Bootz server will not ask clients for a certificate to be presented, but if they do, it must be an IDevID certificate. This allows both legacy and streaming RPC methods to be supported in parallel; Legacy clients will continue to present an IDevID certificate in the TLS handshake and Bootz server will verify this in the handshake. New clients will not present a certificate in the TLS handshake, and so Bootz server will allow the handshake and continue on to the challenge-response step as part of the actual stream.