### PR TITLE
Cisco KNE startup config replace password 7 with plaintext secret

### DIFF
--- a/testdata/cisco.cfg
+++ b/testdata/cisco.cfg
@@ -4,7 +4,7 @@
 username cisco
  group root-lr
  group cisco-support
- password 7 01100F175804575D72
+ secret cisco123
 !
 interface Loopback0
  ipv4 address 44.44.44.44 255.255.255.255


### PR DESCRIPTION
Cisco deprecates Type 7 password in newer releases (https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/security/25xx/configuration/guide/b-system-security-cg-cisco8000-25xx/configuring-aaa-services.html#concept_lbt_ywl_g2c). The "secret" with plaintext is preferred, backward-compatible format.