### PR TITLE
Revise secret for cisco testdata

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -3,3 +3,6 @@
 default.extend-ignore-re = [
   "v\\d+\\.\\d+\\.\\d+-\\d{14}-[a-f0-9]{12}", # Go module pseudo-versions (vX.Y.Z-YYYYMMDDHHMMSS-abcdefabcdef)
 ]
+
+[files]
+extend-exclude = ["testdata/cisco.cfg"]

--- a/testdata/cisco.cfg
+++ b/testdata/cisco.cfg
@@ -4,7 +4,7 @@
 username cisco
  group root-lr
  group cisco-support
- password 7 01100F175804575D72
+ secret 10 $6$nd8Pp1emKxgJDp1.$PeQSLpqjl3esYN6QmpmWPFuS.34wiD7Fb7cxVvx8sQXpvvPwhXVUx5pFm4vRxxrV.qK7uhFKCzdhyDDgXXirE.
 !
 interface Loopback0
  ipv4 address 44.44.44.44 255.255.255.255


### PR DESCRIPTION
As noted in #194, Cisco deprecates Type 7 password in newer releases (https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/security/25xx/configuration/guide/b-system-security-cg-cisco8000-25xx/configuring-aaa-services.html#concept_lbt_ywl_g2c). 

This PR changes the cisco secret to option 10.  (a SHA512 value)