### PR TITLE
TPM 2.0 without idevid/auth proto updates

### DIFF
--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -164,9 +164,9 @@ message BootstrapStreamResponse {
   message Challenge {
     // TPM 2.0 without IDevId may be provisioned using using EK or PPK
     enum TPM20CsrRequest {
-       CSR_REQUEST_UNKNOWN = 0;
-       CSR_REQUEST_EK = 1;
-       CSR_REQUEST_PPK = 2;
+      TPM2_0_CSR_REQUEST_UNSPECIFIED = 0;
+      TPM2_0_CSR_REQUEST_EK = 1;
+      TPM2_0_CSR_REQUEST_PPK = 2;
     }
    
     oneof type {


### PR DESCRIPTION
Trusted Platform Module (TPM) 2.0 without IDevId devices can support either EK or PPK certs. The decision as to which cert to use should be made by the Bootz server, rather than the Bootz agent. The current protocol assumed PPK certs would be used, and the first step in the streaming handshake was the agent sending a ppk_csr. 

These proposed protocol changes introduce an initial step where the device advertises the fact that it is a TPM 2.0 without IDevId device and supports both EK or PPK certs (ek_ppk_pub=True). The Bootz server then responds with an enum indicating which cert should be used when creating the CSR ( tpm20_csr_request=EK_CSR_REQUEST | PPK_CSR_REQUEST). The agent will then generate the appropriate CSR request, return it to the server and the authentication process continues as before.

