### PR TITLE
Fix a few typos, format errors and wording styles for consistency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ consider:
     on the device).
 * The major downside of this approach is fragility - the “dynamic”
     configuration described above is the catch-all configuration for the device,
-    and would ideally replace `/`, however, it can no longer do this, fsince
+    and would ideally replace `/`, however, it can no longer do this, since
     there exists data under the bootstrap configuration (for example,
     `/interfaces` entries that store the management interfaces) and the security
     configuration that must not be replaced. The “dynamic” configuration then
@@ -78,23 +78,23 @@ consider:
 
 * `gnsi.Pathz` policy would limit specific OpenConfig paths from general
     writability
-* The response to the gNMI `SetRequest` that contains the OC configuration
-    change (update, set, delete) is expected to indicate that the request failed
-    if those paths are not writable by the caller
+* The response to the gNMI `SetRequest` that contains the OpenConfig
+    configuration change (update, set, delete) is expected to indicate that the
+    request failed if those paths are not writable by the caller
 * The full config replace would be responsible for only "replacing" specific
     paths rather than a root level replace
-  * /system/&lt;subpaths> but excluding /system/aaa or /interfaces/interfac
-        [name=\*] but exclude /interfaces[name=mgmt0|1], this introduces
-        fragility and complexity in how the /interfaces/interface list, or
-        /system paths are managed since they now have multiple writers.
+  * `/system/<subpaths>` but excluding `/system/aaa`, or `/interfaces/interface
+        [name=\*]` but exclude `/interfaces[name=mgmt0|1]`, this introduces
+        fragility and complexity in how the `/interfaces/interface` list or
+        `/system` paths are managed since they now have multiple writers.
 
 #### Multiple namespaces for the configuration
 
 * This is the approach that has been pursued with gNSI - whereby certain
     subsets of the configuration are moved into a separate namespace (origin in
-    oc naming), which is not manipulated via gNMI’s `Set` RPC. To support the
-    bootstrap configuration, an additional ‘boot’ configuration namespace would
-    be introduced.
+    OpenConfig naming), which is not manipulated via gNMI’s `Set` RPC. To
+    support the bootstrap configuration, an additional ‘boot’ configuration
+    namespace would be introduced.
 * A disadvantage of this approach is the change that it makes to existing
     device configurations, introducing the concept of multiple potentially
     overlapping configurations.
@@ -115,8 +115,8 @@ consider:
     covered data is contained in this namespace.
 * If gNSI is enabled on the device all of the content covered via gNSI is
     interacted with solely within this namespace. To interact with this content,
-    gNSI is used. gNSI SetRequests are ACL'ed via gnsi.Pathz. Additionally, gNSI
-    endpoints would continue to provide set operations as well for those
+    gNSI is used. gNSI `SetRequests` are ACL'ed via `gnsi.Pathz`. Additionally,
+    gNSI endpoints would continue to provide set operations as well for those
     configuration elements.
 * OpenConfig and vendor configuration would not be allowed to configure those
     leaves.
@@ -130,7 +130,7 @@ consider:
     modified through the contents of the `SetRequest`. Specifically, this would
     ensure that:
   * Should the payload of the `SetRequest` specify a path that was in the
-        “paths that are not to be modified list” an error would be returned.
+        “paths that are not to be modified" list, an error would be returned.
   * `Replace` operations that give the declarative set of end contents for a
         particular path would exclude these being replaced (e.g., a `replace`
         operation that impacted `/system`, along with a payload that specified
@@ -158,7 +158,7 @@ consider:
 * Currently, for some implementations this behavior can be achieved via a
     proprietary switch within the vendor-configuration that excludes specific
     paths from being settable from gNMI.
-  * In this implementation any attempts to "set an excluded" path is
+  * In this implementation any attempts to "set an excluded path" is
         ignored.
   * This is not advisable as it makes it very opaque during a set as to why
         a set is having a specific output.
@@ -179,7 +179,7 @@ The proposed operational model for devices is shown in Figure 1 above.
     considered part of security/auth namespace. gNSI manages this configuration
     store completely. It is considered a “precedence 0” store, whereby it is the
     authoritative source of configuration in the case of any overlap with other
-    namespace. Explicitly, this means that gNSI owns this configuration, and
+    namespaces. Explicitly, this means that gNSI owns this configuration, and
     calls must be made to gNSI to mutate this store.
 * Boot configuration (discussed in more detail in this document) is considered
     part of a bootstrap namespace. gNOI.Bootz manages this configuration store
@@ -191,21 +191,21 @@ The proposed operational model for devices is shown in Figure 1 above.
         to be modified, it would be changed through calling a `Set` RPC through
         the `Bootz` service.
   * When changing this configuration the device must "reapply" configuration
-        just as would be expected through a controller doing a gnmi.Set
+        just as would be expected through a controller doing a `gnmi.Set`
         union-merge.
 * Dynamic configuration reflects the current, widely-understood concept of
     configuration on a network device. It is managed via gNMI. Each origin
     within gNMI is assigned an explicit precedence. The precedence for origins
     is defined in the relevant document - but the value suggested is >=
-    100,i.e., for overlaps with other namespaces it is explicitly ignored.
-  * It is expected that this is needed in the case that:
+    100, i.e., for overlaps with other namespaces it is explicitly ignored.
+    It is expected that this is needed in the case that:
   * `/system/aaa` is populated on the device running gNSI. In such a case,
         gNSI (in the auth namespace) is the source of truth.
   * Management interfaces, or running gRPC daemons are specified in the Boot
         namespace, also in the `/system` or `/interfaces` hierarchies within the
         dynamic configuration.
 
-CLI(via SSH or Console) as an API should have access to all the 3 name spaces
+CLI (via SSH or Console) as an API should have access to all the 3 namespaces
 above. It provides a low dependency method to recover the device in case of
 bugs/failures/emergencies.
 
@@ -225,7 +225,7 @@ turn-up time that become part of the “boot” process. Specifically, we are
 suggesting that TPM-related enrollment and attestation should be required during
 the boot process to ensure the authenticity and integrity of the device
 **before** providing it with potentially sensitive artifacts such as
-certificates, key and device configuration.
+certificates, keys and device configuration.
 
 ### Reference Documentation
 
@@ -252,7 +252,7 @@ components, etc.
 The bootz payload will be encrypted via the TLS session underlying the gRPC
 service.
 
-Depends on the security requirement for the deployment environment, after
+Depending on the security requirement for the deployment environment, after
 loading all the provided data on first boot the device might still not be in a
 trusted state, however it should have enough g\* services initialized to a state
 where the device can be interrogated from a trusted system to enroll the TPM and
@@ -269,16 +269,16 @@ can install production configuration and certificates into the device.
         mac-addresses of the device, and responds with the static IP address of
         the bootstrap server.
     2. DHCP server also assigns an IP address and a gateway to the device.
-    3. The DHCP response option code should be OPTION_V4_SZTP_REDIRECT(143) or
-        OPTION_V6_SZTP_REDIRECT(136).
+    3. The DHCP response option code should be `OPTION_V4_SZTP_REDIRECT` (143)
+        or `OPTION_V6_SZTP_REDIRECT` (136).
     4. The format of the DHCP message (other than response option code) follows
         [RFC](https://www.rfc-editor.org/rfc/rfc8572#page-56).
-        1. The URI will be in the format of bootz://&lt;host or ip>:&lt;port>
+        1. The URI will be in the format of `bootz://<hostname or ip>:<port>`
 2. Bootstrapping Service
-    1. Device initiates a gRPC connection to the bootz-server whose address was
-        obtained from the DHCP server.
+    1. Device initiates a gRPC connection `Bootstrap.GetBootstrappingData` to
+        the bootz-server whose address was obtained from the DHCP server.
     2. The TLS connection **MUST** be secured on the client-side with the
-        IDevId of the active control card.
+        IDevID of the active control card.
     3. The responses from the bootz-server are signed by ownership-certificate.
         The device validates the ownership-voucher, which authenticates the
         ownership-certificate. The device verifies the signature of the message
@@ -296,23 +296,24 @@ the ownership voucher and ownership certificate.
 1. Ownership Voucher and Ownership Certificate
     1. These artifacts have the same meaning as the original sZTP
         [RFC](https://www.rfc-editor.org/rfc/rfc8572#section-3.2). This document
-        uses OC and PDC interchangeably for convenience. However, we should keep
-        in mind that OV authenticates a PDC (Pinned Domain Cert), and OC might
-        be a distinct certificate with a chain of trust to the PDC.
-    2. The contents of the GetBootstrappingDataResponse has an inner message
+        uses OC (Ownership Certificate) and PDC (Pinned Domain Cert)
+        interchangeably for convenience. However, we should keep in mind that
+        OV (Ownership Voucher) authenticates a PDC, and OC might be a distinct
+        certificate with a chain of trust to the PDC.
+    2. The contents of the `GetBootstrappingDataResponse` has an inner message
         body. The outer message contains the Ownership Voucher, the Ownership
         Certificate and a signature over the inner message body. The signature
         is generated using the OC and the nonce.
 2. GetBootstrappingData
     1. The bootz workflow is initiated by the device sending a
-        GetBootstrappingData RPC to the bootz-server.
+        `GetBootstrappingData` gRPC to the bootz-server.
     2. The device describes itself, by listing out all available control cards,
         and their states.
     3. For a full device install, the state of all control cards is
-        NOT\_INITIALIZED.
+        `NOT_INITIALIZED`.
     4. For installing hot-swapped modules (RMA), the primary control card sets
-        its state to INITIALIZED, and that of the swapped module to
-        NOT\_INITIALIZED.
+        its state to `INITIALIZED`, and that of the swapped module to
+        `NOT_INITIALIZED`.
 3. GetBootstrappingDataResponse
     1. The server responds with the intent for the device's baseline state.
         This includes the OS version and boot password hash, and an initial
@@ -322,28 +323,29 @@ the ownership voucher and ownership certificate.
         to enrollment and attestation or even bring the device fully into a
         production state.
     2. The proto allows us to return multiple sets of configurations, one per
-        control card. However, in practice, we will apply the same configuration
-        to both cards.
-    3. For RMA, the server will return only one state - for the RMA'd module.
+        control card. However, in practice, we usually apply the same
+        configuration to both cards.
+    3. For RMA, the server will return only one set of configuration - for
+        the RMA'd module.
     4. The device/modules should download the OS image, verify its hash and
         install the OS.
         1. A reboot may be performed, if required.
-    5. The device will then apply the configuration
+    5. The device/modules will then apply the configuration.
         1. A reboot may be performed, if required.
-    6. The GetIntendedState RPC can be performed as many times as required
+    6. The `GetBootstrappingData` gRPC can be performed as many times as required
         (i.e. it is idempotent).
 4. ReportProgress
-    1. This RPC method is used by the device to inform the bootz server that
+    1. This gRPC method is used by the device to inform the bootz server that
         the bootstrapping process is complete. Success or failure is indicated
         using an enum.
     2. In case of failure, the device should retry this process from Step 1.
-    3. When making this RPC, the device should verify the identity of the
+    3. When making this gRPC, the device should verify the identity of the
         server using the "`server_trust_cert`" certificate obtained from
-        GetBootstrappingDataResponse.
+        `GetBootstrappingDataResponse`.
     4. "`server_trust_cert`" plays the same role as "trust-anchor" in the sZTP
         RFC (i.e. allows the device to verify the identity of the server).
 5. At this point, the device has a minimal set of configuration, enabling it to
-    receive grpc calls. Depending on the operator's security policies, an
+    receive gRPC calls. Depending on the operator's security policies, an
     attestation-verification or an enrollment step may be performed.
     1. At Google, we plan to always require enrollment and
         attestation-verification.
@@ -356,7 +358,7 @@ the ownership voucher and ownership certificate.
         is independent of the device vendor.
     3. The TpmEnrollment API is secured with the IDevID certificate.
     4. During enrollment, the server **MUST** verify that the serial number on
-        the Attestation Key certificate matches the serial number on the DevID
+        the Attestation Key certificate matches the serial number on the IDevID
         certificate, and validate both certificates with the appropriate trust
         bundle.
 7. Attestation
@@ -364,26 +366,26 @@ the ownership voucher and ownership certificate.
         API is reproduced here for convenience.
     2. This step allows the owner to obtain cryptographic evidence for the
         integrity of the software components on the control-cards.
-    3. The attestation API should be secured with DevID for the first
-        attestation, and mtls for subsequent attestations.
+    3. The attestation API should be secured with IDevID for the first
+        attestation, and mTLS for subsequent attestations.
         1. On first attestation, the server **MUST** verify that the serial
             number on the Attestation Key certificate matches the serial number
-            on the DevID certificate, and validate both certificates with the
+            on the IDevID certificate, and validate both certificates with the
             appropriate trust bundle.
     4. On modular devices, the active control card obtains attestation evidence
-        from the standby, and relays it to the bootz server. The active card
-        must verify the identity of the standby during this process. The standby
-        card's ability to communicate with the active card is not sufficient
-        evidence of identity.
+        from the standby, and relays it to the bootz server. The active control
+        card must verify the identity of the standby during this process. The
+        standby control card's ability to communicate with the active card is
+        not sufficient evidence of identity.
         1. This specification does not prescribe how to verify the identity of
             the standby, as the communication between the control cards takes
             place over vendor-proprietary protocols. However, at a minimum, the
-            active supervisor must check that the standby's TPM-backed IDevID.
+            active control card must check that the standby's TPM-backed IDevID.
             For example, it may request the IDevID cert, then issue a decrypt
-            challenge to the standby card.
+            challenge to the standby control card.
 8. Final state:
-    1. At this point, the device an initial configuration, user accounts, and
-        we have validated the identity and integrity of the device and its
+    1. At this point, the device has an initial configuration and user accounts.
+        We have validated the identity and integrity of the device and its
         software components. It is ready to serve traffic.
 
 ### Bootz Procedure (BootstrapStream)
@@ -394,25 +396,25 @@ the ownership voucher and ownership certificate.
         mac-addresses of the device, and responds with the static IP address of
         the bootstrap server.
     2. DHCP server also assigns an IP address and a gateway to the device.
-    3. The DHCP response option code should be OPTION_V4_SZTP_REDIRECT(143) or
-        OPTION_V6_SZTP_REDIRECT(136).
+    3. The DHCP response option code should be `OPTION_V4_SZTP_REDIRECT` (143)
+        or `OPTION_V6_SZTP_REDIRECT` (136).
     4. The format of the DHCP message (other than response option code) follows
         [RFC](https://www.rfc-editor.org/rfc/rfc8572#page-56).
-        1. The URI will be in the format of bootz://<host or ip>:<port>
+        1. The URI will be in the format of `bootz://<hostname or ip>:<port>`
 2. Bootstrapping Service
-    1. Device initiates a gRPC connection to the bootz-server whose address was
-        obtained from the DHCP server.
-    2. The device **must not** present a client certificate in the TLS handshake.
+    1. Device initiates a gRPC connection `Bootstrap.GetBootstrappingData` to
+        the bootz-server whose address was obtained from the DHCP server.
+    2. The device **MUST NOT** present a client certificate in the TLS handshake.
     4. The responses from the bootz-server are signed by ownership-certificate.
         The device validates the ownership-voucher, which authenticates the
         ownership-certificate. The device verifies the signature of the message
         body before accepting the message.
     5. If the signature could not be verified, the bootstrap process starts
         from Step 1.
-2. BootstrapStreamRequest.bootstrap_request
+3. BootstrapStreamRequest.bootstrap\_request
     1. The bootz BootstrapStream is initiated by the device sending a
-        GetBootstrappingData message to the bootz-server in the first message
-        of the stream.
+        `GetBootstrapDataRequest` message to the bootz-server in the first
+        message of the stream.
     3. The device describes itself, by listing out all available control cards,
         and their states.
     4. For a full device install, the state of all control cards is
@@ -420,39 +422,39 @@ the ownership voucher and ownership certificate.
     5. For installing hot-swapped modules (RMA), the primary control card sets
         its state to `INITIALIZED`, and that of the swapped module to
         `NOT_INITIALIZED`.
-    6. The device sets Identity.ek_pub=true in the bootstrap_request if it has
-        a TPM 1.2.
-3. BootstrapStreamResponse.challenge
+    6. The device sets `Identity.ek_pub=true` in the `bootstrap_request` if it
+        has a TPM 1.2.
+4. BootstrapStreamResponse.challenge
     1. The server will provide a challenge depending on the data fetched from
-        OVGS server based on the GetBootstrapDataRequest.identity.
-    2. For TPM2.0 with iDevID
-       1. The iDevID cert will be validated and the S/N will
-           will be used to validate the device.
+        OVGS (Ownership Voucher gRPC Service) server based on the
+        `GetBootstrapDataRequest.identity`.
+    2. For TPM2.0 with IDevID
+       1. The IDevID cert will be validated and the S/N will be used to validate
+           the device.
        2. The Challenge will be returned.
-    3. For non-iDevID systems
-       1. The GetBootstrapDataRequest.chassis_descriptor data will be used to
+    3. For non-IDevID systems
+       1. The `GetBootstrapDataRequest.chassis_descriptor` data will be used to
            validate the S/N.
-       2. This will then be validated by lookup in OVGS and then used the keys
+       2. This will then be validated by lookup in OVGS and then use the keys
            returned to encrypt the challenge.
-       3. For devices which have an TPM 1.2, the server sends its certificate
+       3. For devices which have TPM 1.2, the server sends its certificate
            authority's public key so that the device can send a CSR-like
            request securely.
-4. EkIdentityRequest - Applicable only for devices having TPM 1.2
+5. EkIdentityRequest - Applicable only for devices having TPM 1.2
     1. The device sends the EK public key and an Identity request to the server.
-5. EkIdentityResponse - Applicable only for devices having TPM 1.2
-    1. The server extracts the modulus, exponent from the EK public key
-        and sends an challenge which can be responded only by the intended
-        TPM.
-6. BootstrapStreamRequest.response
-    1. The response message will contain the nonce signed via IAK for
-        TPM 2.0 system with iDevID. This will validate that the device is
+6. EkIdentityResponse - Applicable only for devices having TPM 1.2
+    1. The server extracts the modulus and exponent from the EK public key,
+        and sends a challenge which can be responded only by the intended TPM.
+7. BootstrapStreamRequest.response
+    1. The `Response` message will contain the nonce signed via IAK for
+        TPM 2.0 system with IDevID. This will validate that the device is
         in fact the device expected.
     2. For all other systems the returned value will be the unencryted nonce.
     3. If the challenge response is valid the server will send the bootstrap
         data.
     4. If the challenge fails an error will be returned and the device must
-        start over at step 1.
-7. BootstrapStreamResponse.bootstrap_response
+        start over from Step 1.
+8. BootstrapStreamResponse.bootstrap\_response
     1. The server responds with the intent for the device's baseline state.
         This includes the OS version and boot password hash, and an initial
         device configuration. This would include initial gNSI artifacts
@@ -461,40 +463,41 @@ the ownership voucher and ownership certificate.
         to enrollment and attestation or even bring the device fully into a
         production state.
     2. The proto allows us to return multiple sets of configurations, one per
-        control card. However, in practice, we will apply the same configuration
-        to both cards.
-    3. For RMA, the server will return only one state - for the RMA'd module.
+        control card. However, in practice, we usually apply the same
+        configuration to both cards.
+    3. For RMA, the server will return only one set of configuration - for the
+        RMA'd module.
     4. The device/modules should download the OS image, verify its hash and
         install the OS.
         1. A reboot may be performed, if required.
-    5. The device will then apply the configuration
+    5. The device/modules will then apply the configuration.
         1. A reboot may be performed, if required.
-8. BootstrapStreamRequest.report_status_request
-    1. The device sends a ReportStatusRequest message to the bootz-server.
-    2. If bootstrapping is successful, the device should report all control cards as `CONTROL_CARD_STATUS_INITIALIZED` and `BOOTSTRAP_STATUS_SUCCESS`.
-    3. If bootstrapping is not successful, the device *may* report status as `BOOTSTRAP_STATUS_FAILURE` and then should restart the process from step 1.
-    4. If the device terminated the previous stream (due to a reboot or to apply a configuration)
-        1. The server responds with a BootstrapStreamResponse.challenge to re-authenticate with the device (see step 7).
-    5. If the device *did not* terminate the previous stream
-        1. the server responds with a ReportStatusResponse (See step 9)
-9. BootstrapStreamResponse.challenge
-    1. The same challenge protocol as described in step 3 is performed.
-10. BootstrapStreamRequest.response
-     1. The same response protocol as described in step 4 is performed.
-11. BootstrapStreamResponse.report_status_response
-     1. The server responds with an empty message acknowledging the status report.
-
+9. BootstrapStreamRequest.report\_status\_request
+    1. The device sends a `ReportStatusRequest` message to the bootz-server.
+    2. If bootstrapping is successful, the device should report all control
+        cards as `CONTROL_CARD_STATUS_INITIALIZED` and
+        `BOOTSTRAP_STATUS_SUCCESS`.
+    3. If bootstrapping is not successful, the device *may* report status as
+        `BOOTSTRAP_STATUS_FAILURE` and then should restart the process from
+        Step 1.
+    4. If the device terminated the previous stream (due to a reboot or to apply
+        a configuration).
+        1. The server responds with a `BootstrapStreamResponse.challenge` to
+            re-authenticate with the device (i.e restart from Step 4).
+    5. If the device *did not* terminate the previous stream.
+        1. the server responds with an empty `ReportStatusResponse` message
+            to acknowledge the status report.
 
 ### A Note on Modular Devices
 
 Many commercial modular form-factor devices start copying data from the active
-control card to a hot-swapped standby immediately on plug-in. This includes
+control card to a hot-swapped standby immediately on plugging in. This includes
 sensitive data such as credentials and certificates. From a security standpoint,
 this is undesirable.
 
 We recommend that the active card copy system software only (includes firmware,
 bootloader, boot password and OS image), then restart the hot-swapped card. It
-should verify the standby card's identity (using DevID verified against the
+should verify the standby card's identity (using IDevID verified against the
 vendor root of trust) and attestation evidence (which should match the active
 card's PCR values) before copying the operator-provided operational
 configuration.
@@ -508,22 +511,23 @@ configuration.
 1. Card failure detected
 2. Card RMA issued
 3. Card replaced
-4. Active control card detects new linecard
-5. Active control card tries to verify card via IDevID
-6. Active control card verifies card software and firmware is at least at it's
-    version a. if not will send over the firmware and software and perform an
-    upgrade.
+4. Active control card detects new standby control card
+5. Active control card tries to verify new standby card via IDevID
+6. Active control card verifies standby card software and firmware is at least
+    at it's own version.
+    a. If not, it will send over the firmware and software and perform an
+        upgrade.
 7. The chassis will update gNMI with component in inserted but not enrolled
     state.
-8. Kick of workflow for initialization of new control card a. Inventory system
-    detects unenrolled control card kicks off workflow to the
-    enrollment/attestion system. b. Active control card send bootz request to
-    bootserver containing serial number of new card and will get back bootz
-    artifacts.
-9. Planet service makes call to enrollment API and provides proper OV for the
-    control card.
-10. Planet service makes call to attestation API to verify attestation values.
-11. Active control card now verifies the card and brings the card into
+8. Kick off workflow for initialization of new control card
+    a. Inventory system detects unenrolled control card and kicks off workflow
+        to the enrollment/attestion system.
+    b. Active control card sends bootz request to bootserver containing serial
+        number of new card, and gets back bootz artifacts.
+9. Inventory service makes call to enrollment API and provides proper OV for the
+    new control card.
+10. Inventory service makes call to attestation API to verify attestation values.
+11. Active control card now verifies the new card, brings the new card into
     production state and sync's configuration and other files.
 
 ### Certificate deployment options
@@ -540,9 +544,9 @@ security profile and certificates provided in the bootz message.
 
 ![Alt text](design_images/bootz_certz.png "Certs delivered via Certz")
 
-In this workflow the device will boot from bootz but will use it's iDevID cert
+In this workflow the device will boot from bootz but will use it's IDevID cert
 for initial services. Once rebooted, the device can be reached via Certz using
-the iDevID cert.
+the IDevID cert.
 
 #### Bootz with Enrollz and Attestz
 
@@ -554,7 +558,7 @@ validate the state of device before providing any "production" certificates.
 
 ### Protobuf Payload for Bootstrap
 
-The following protocol buffer is provided from the bootserver to the device to
+The following protocol buffer is provided from the bootz-server to the device to
 provide the bundle of artifacts needed for the device to reach a manageable
 state.
 

--- a/proto/bootz.proto
+++ b/proto/bootz.proto
@@ -49,8 +49,8 @@ service Bootstrap {
   // BootstrapStream provides the streaming implementation of the Bootz
   // service. This flow allows for both server and client validation via
   // nonces and certificate validation. This allows the service to start with
-  // non owner signed certificates and build trust relationship.
-  // This bypasses the need to require the iDevID cert to be sent as part of
+  // non owner signed certificates and build a trust relationship.
+  // This bypasses the need to require the IDevID cert to be sent as part of
   // the initial gRPC TLS handshake.
   // The workflow should follow:
   //    BootstrapStreamRequest.bootstrap_request
@@ -62,18 +62,18 @@ service Bootstrap {
       returns (stream BootstrapStreamResponse) {}
 }
 
-// Describes how the device will prove its identity to the Bootstrap server
-// during the BootstreapStream() RPC.
-// For systems which support iDevID that will be the preferred method.
-// If identity is set one of the types must be set or an error is
-// returned.
+// Identity describes how the device will prove its identity to the Bootstrap
+// server during the BootstreapStream() RPC.
+// For systems which support IDevID that will be the preferred method.
+// If identity is set, one of the types must be set or an error is returned.
 message Identity {
   oneof type {
-    // idevid_cert will be validated via OVGS and the vendor CA bundle.
-    // Additional it will be used to validate the nonce_signed.
+    // idevid_cert will be validated via OVGS (Ownership Voucher gRPC Service)
+    // and the vendor CA bundle.
+    // Additionally it will be used to validate the nonce_signed.
     // The format is a base64 encoding of an x509 DER certificate.
     string idevid_cert = 1;
-    // One of the key types must be set for non-iDevID based systems.
+    // One of the key types must be set for non-IDevID based systems.
     // The public keys will be used to encrypt the nonce and validate
     // that the keys match the data in OVGS. The decrypted
     // nonce will be returned to validate the device identity.
@@ -87,7 +87,7 @@ message Identity {
     // Deprecated: Use ek_ppk_pub instead.
     bytes ppk_csr = 4 [deprecated = true];
     
-    // TPM 2.0 without IDevId, device supports both EK and PPK
+    // TPM 2.0 without IDevId. Device supports both EK and PPK.
     bool ek_ppk_pub = 5;
   }
 }
@@ -107,21 +107,21 @@ message GetBootstrapDataRequest {
 
   // Identity will contain information used to validate the identity
   // of the device.
-  // For systems which support iDevID that will be the preferred method.
-  // If identity is set one of the types must be set or an error is
+  // For systems which support IDevID that will be the preferred method.
+  // If identity is set, one of the types must be set or an error is
   // returned.
   Identity identity = 1003;
 } 
 
-// BootstrapStreamRequest is used to both build send chassis information
-// as well as build a trust relationship if the iDevID cert is not used
+// BootstrapStreamRequest is used to both send chassis information
+// as well as build a trust relationship if the IDevID cert is not used
 // during TLS setup.
 message BootstrapStreamRequest {
   message Response {
     oneof type {
-      // Nonce to be signed with IAK from the device for iDevID based systems.
+      // Nonce to be signed with IAK from the device for IDevID based systems.
       bytes nonce_signed = 1;
-      // For non-iDevID systems the encrypted nonce will be decrypted via:
+      // For non-IDevID systems the encrypted nonce will be decrypted via:
       // TPM 2.0: PPK
       // TPM 1.2: EK
       string nonce = 2;
@@ -159,11 +159,11 @@ message BootstrapStreamRequest {
 } 
 
 // BootstrapStreamResponse will be returned based on the request from the
-// client. The challenge will be based on the data provided in the initial
-// GetBootstrapDataRequest based on the identity message.
+// client. The challenge will be based on the Identity message provided in
+// the initial GetBootstrapDataRequest message.
 message BootstrapStreamResponse {
   message Challenge {
-    // TPM 2.0 without IDevId may be provisioned using using EK or PPK
+    // TPM 2.0 without IDevId may be provisioned using EK or PPK
     enum TPM20CsrRequest {
       TPM2_0_CSR_REQUEST_UNSPECIFIED = 0;
       TPM2_0_CSR_REQUEST_EK = 1;
@@ -171,15 +171,14 @@ message BootstrapStreamResponse {
     }
    
     oneof type {
-      // nonce will be returned for iDevID based system for signing by IAK.
+      // nonce will be returned for IDevID based system for signing by IAK.
       string nonce = 1;
-      // nonce_encrypted will be returned for non-iDevID based systems.
+      // nonce_encrypted will be returned for non-IDevID based systems.
       // The public key used to encrypt the data will be based on the 
-      // public key provided by OVGS. This maybe EK or PPK.
+      // public key provided by OVGS, which may be EK or PPK.
       bytes nonce_encrypted = 2; 
       // TPM 1.2 EK CA public cert
       bytes ca_pub = 3;
-
       // TPM 2.0 without IDevId
       TPM20CsrRequest tpm20_csr_request = 4;
     } 
@@ -200,19 +199,19 @@ message BootstrapStreamResponse {
 }
 
 // Structured message containing the chassis details, and listing its component
-// control-card modules.
+// control card modules.
 message ChassisDescriptor {
   string manufacturer = 1;
   string part_number = 2;
-  // This field must be populated for fixed form-factor chassis.
-  // The serial can be empty for modular chassis.
+  // This field must be populated for fixed form factor chassis.
+  // The serial number can be empty for modular chassis.
   string serial_number = 3;
   // For modular chassis this field will be used to list the control cards
   // to be bootstrapped.
   repeated ControlCard control_cards = 4;
 }
 
-// Details of the control card, including serial-number and the location
+// Details of the control card, including serial number and the location
 // of the card on the chassis.
 message ControlCard {
   string part_number = 1;
@@ -227,36 +226,36 @@ message ControlCard {
 // At the beginning of the bootstrap process (i.e. before a
 // ReportStatus has completed with BOOTSTRAP_STATUS_SUCCESS),
 // all control cards (1 or 2) are in NOT_INITIALIZED state.
-// If bootstrap successfully completes for a control-card, the
+// If bootstrap successfully completes for a control card, its
 // ControlCardStatus changes to INITIALIZED.
 //
-// Once a control-card is in INITIALIZED state, it may remain in that
+// Once a control card is in INITIALIZED state, it may remain in that
 // state indefinitely, even if removed and reinstalled in a chassis.
 //
-// When there are 2 control-cards present and INITIALIZED and 1 is
+// When there are 2 control cards present and INITIALIZED then one is
 // removed, the remaining control card remains in INITIALIZED state.
-// If a new control-card is inserted which has never completed the
+// If a new control card is inserted which has never completed the
 // bootstrap process, it will start with NOT_INITIALIZED state.
 message ControlCardState {
 
   enum ControlCardStatus {
-    // the bootstrap process status is not reported.
+    // The bootstrap process status is not reported.
     CONTROL_CARD_STATUS_UNSPECIFIED = 0;
-    // the bootstrap process has not successfully completed.
+    // The bootstrap process has not successfully completed.
     CONTROL_CARD_STATUS_NOT_INITIALIZED = 1;
-    // the bootstrap process has successfully completed.
+    // The bootstrap process has successfully completed.
     CONTROL_CARD_STATUS_INITIALIZED = 2;
   }
 
-  // Serial must align with the serial number of the provided
+  // serial_number must align with the serial number of the provided
   // control card in the chassis descriptor.
   string serial_number = 1;
   ControlCardStatus status = 2;
 }
 
 message BootstrapDataResponse {
-  // The serial number of the control card to which this state should
-  // be applied.
+  // The serial number of the control card to which this bootstrap data
+  // should be applied.
   string serial_num = 1;
   // The device should download and install this image (or skip if the
   // device is already running it).
@@ -276,13 +275,13 @@ message BootstrapDataResponse {
 }
 
 // CertzProfiles contains the Certz profiles and entities to create.
-// The profiles cannot contain duplicate id's and must never contain
-// the id `system_default_profile`.
+// The profiles cannot contain duplicate ID's and must never contain
+// the ID `system_default_profile`.
 message CertzProfiles {
   repeated CertzProfile profiles = 1;
 }
 
-// CertzProfile is the profile ID and Certz entities for the profile.
+// CertzProfile contains the profile ID and Certz entities for the profile.
 message CertzProfile {
   string ssl_profile_id = 1;
   gnsi.certz.v1.UploadRequest certz = 2; 
@@ -330,8 +329,7 @@ message GetBootstrapDataResponse {
   bytes serialized_bootstrap_data = 104;
 }
 
-// Fields required by the device to be able to
-// download and verify an image.
+// Fields required by the device to be able to download and verify an image.
 // The format of this message is identical to the `boot-image` data 
 // model outlined in the sZTP RFC:
 // https://datatracker.ietf.org/doc/html/rfc8572#section-6.1
@@ -347,7 +345,7 @@ message SoftwareImage {
   // `hex-string`, identified in RFC6991 as "A hexadecimal string with 
   // octets represented as hex digits separated by colons.
   // The canonical representation uses lowercase characters."
-  // e.g.: "d9:a5:d1:0b:09:fa:4e:96:f2:40:bf:6a:82:f5"
+  // E.g.: "d9:a5:d1:0b:09:fa:4e:96:f2:40:bf:6a:82:f5"
   string os_image_hash = 4;
   // The identity of the hash algorithm used. These hash identiities are 
   // defined in sZTP RFC 8572. There is currently only one hash algorithm
@@ -363,7 +361,7 @@ message Credentials {
 }
 
 message BootConfig {
-  // Proprietary key-value parameters that are required as part of boot
+  // Proprietary key-value pairs that are required as part of boot
   // configuration (e.g., feature flags, or vendor-specific hardware knobs).
   google.protobuf.Struct metadata = 1;
 
@@ -385,7 +383,7 @@ message BootConfig {
   // 
   // Native format vendor configuration.
   bytes vendor_config = 2;
-  // JSON rendered OC configuration.
+  // JSON rendered OpenConfig configuration.
   bytes oc_config = 3;
 
   // dynamic_vendor_config and dynamic_oc_config specify boot configuration
@@ -397,15 +395,15 @@ message BootConfig {
   //
   // Native format vendor configuration.
   bytes dynamic_vendor_config = 5;
-  // JSON rendered OC configuration.
+  // JSON rendered OpenConfig configuration.
   bytes dynamic_oc_config = 6;
 
-  // Bootloader key-value parameters that are required as part of boot
+  // Bootloader key-value pairs that are required as part of boot
   // configuration.
   google.protobuf.Struct bootloader_config = 4;
 }
 
-// The device reports the status of applying Bootstrap data using this service.
+// The device reports the status of applying bootstrap data using this service.
 // The status_message is a human-readable message indicating the nature of
 // failure, if any.
 message ReportStatusRequest {
@@ -423,18 +421,18 @@ message ReportStatusRequest {
   repeated ControlCardState states = 3;
   // Identity will contain information used to validate the identity
   // of the device.
-  // For systems which support iDevID that will be the preferred method.
-  // If identity is set one of the types must be set or an error is
+  // For systems which support IDevID that will be the preferred method.
+  // If identity is set, one of the types must be set or an error is
   // returned.
   Identity identity = 4;
 }
 
-// Used in  RPC methods that are not expected to return a response.
+// Used in RPC methods that are not expected to return a response.
 message EmptyResponse {
 }
 
-// BootMode specifies if the chassis should utilize OV data.
-// Secure mode uses the OV validation.
+// BootMode specifies if the chassis should utilize Ownership Voucher data.
+// Secure mode uses the Ownership Voucher validation.
 enum BootMode {
   BOOT_MODE_UNSPECIFIED = 0;
   BOOT_MODE_INSECURE = 1;


### PR DESCRIPTION
Expain a few acronyms when they first appear in the file.