### PR TITLE
Implement TPM 2.0 IDevID bootstrap response for Streaming Bootz v1.0.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,9 @@ jobs:
       contents: read
     strategy:
       matrix:
-        go: ["1.24", "1.x"]
+        go: ["1.26.1"]
+    env:
+      GOTOOLCHAIN: "go${{ matrix.go }}"
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -50,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: "1.x"
+          go-version: "1.26.1"
       - name: Run Coverage
         run: go test -v -coverprofile=profile.cov ./...
       - name: Send coverage
@@ -70,7 +72,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: "1.x"
+          go-version: "1.26.1"
         id: go
       - name: Install required static analysis tools
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "openconfig_gnmi", version = "0.14.1")
 bazel_dep(name = "openconfig_gnsi", version = "1.9.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.25.5")
+go_sdk.download(version = "1.26.1")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1943,166 +1943,162 @@
           "04bc3c078e9e904c4d58d6ac2532a5bdd402bd36a9ff0b5949b3c5e6006a05ee"
         ]
       },
-      "1.25.5": {
+      "1.26.1": {
         "aix_ppc64": [
-          "go1.25.5.aix-ppc64.tar.gz",
-          "89d3300aeb8a49354c04d43abf2a0dca6a75ac772b3bc2edaac52de513041572"
+          "go1.26.1.aix-ppc64.tar.gz",
+          "75441456c5fb8338b2691d22d7e91cc756f79defaa4268d6e04ab85ca1a1f4a3"
         ],
         "darwin_amd64": [
-          "go1.25.5.darwin-amd64.tar.gz",
-          "b69d51bce599e5381a94ce15263ae644ec84667a5ce23d58dc2e63e2c12a9f56"
+          "go1.26.1.darwin-amd64.tar.gz",
+          "65773dab2f8cc4cd23d93ba6d0a805de150ca0b78378879292be0b903b8cdd08"
         ],
         "darwin_arm64": [
-          "go1.25.5.darwin-arm64.tar.gz",
-          "bed8ebe824e3d3b27e8471d1307f803fc6ab8e1d0eb7a4ae196979bd9b801dd3"
+          "go1.26.1.darwin-arm64.tar.gz",
+          "353df43a7811ce284c8938b5f3c7df40b7bfb6f56cb165b150bc40b5e2dd541f"
         ],
         "dragonfly_amd64": [
-          "go1.25.5.dragonfly-amd64.tar.gz",
-          "51478a265f45b68ce761aa303c1ecf185949f6eb0b2106e3066ec4d32361b38a"
+          "go1.26.1.dragonfly-amd64.tar.gz",
+          "f415e65bfcb03989a4b6eddedcd582cd509ea619af588b1341416216642c78fb"
         ],
         "freebsd_386": [
-          "go1.25.5.freebsd-386.tar.gz",
-          "f8ff9fa5309fbbbd7d52f5d3f7181feb830dfd044d23c38746a2ada091f751b5"
+          "go1.26.1.freebsd-386.tar.gz",
+          "afb86dcd5240cf93627171a169973c75d9d139a69ed8e0be120d49b24943c13f"
         ],
         "freebsd_amd64": [
-          "go1.25.5.freebsd-amd64.tar.gz",
-          "a2d2b2aeb218bd646fd8708bacc96c9d4de1b6c9ea48ceb9171e9e784f676650"
+          "go1.26.1.freebsd-amd64.tar.gz",
+          "d89034a0b54fdc234815fecfb76d7d06a7d180d7a6124aa47715a4cacc9fe999"
         ],
         "freebsd_arm": [
-          "go1.25.5.freebsd-arm.tar.gz",
-          "b83a5cb1695c7185a13840661aef6aa1b46202d41a72528ecde51735765c6641"
+          "go1.26.1.freebsd-arm.tar.gz",
+          "c60b5b09a24680e40a906df62af71563af4cca0106f01390f2a2346bbfbc4aaa"
         ],
         "freebsd_arm64": [
-          "go1.25.5.freebsd-arm64.tar.gz",
-          "938fc0204f853c24ab03967105146af6590903dd14f869fe912db7a735f654f6"
-        ],
-        "freebsd_riscv64": [
-          "go1.25.5.freebsd-riscv64.tar.gz",
-          "7b0cc61246cf6fc9e576135cfcd2b95e870b0f2ee5bf057325b2d76119001e4e"
+          "go1.26.1.freebsd-arm64.tar.gz",
+          "d62b358dbf7bcfc33402e7e221d848e7fd8d7ac902b33920f2c23c8a32ba76db"
         ],
         "illumos_amd64": [
-          "go1.25.5.illumos-amd64.tar.gz",
-          "ea5cafcf995ef4a82ced5a7134f18bbc5ca554c345075d18f37d2e192fe2c1ff"
+          "go1.26.1.illumos-amd64.tar.gz",
+          "78e9a3d99fab9626b773a859f28f69ca5240846487f51b92b51251ef04f210bc"
         ],
         "linux_386": [
-          "go1.25.5.linux-386.tar.gz",
-          "db908a86e888574ed3432355ba5372ad3ef2c0821ba9b91ceaa0f6634620c40c"
+          "go1.26.1.linux-386.tar.gz",
+          "da75d696c6b9440fe9fb6418429f29eaeee947707ee8c6ddb567c558051a1cc2"
         ],
         "linux_amd64": [
-          "go1.25.5.linux-amd64.tar.gz",
-          "9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b"
+          "go1.26.1.linux-amd64.tar.gz",
+          "031f088e5d955bab8657ede27ad4e3bc5b7c1ba281f05f245bcc304f327c987a"
         ],
         "linux_arm64": [
-          "go1.25.5.linux-arm64.tar.gz",
-          "b00b694903d126c588c378e72d3545549935d3982635ba3f7a964c9fa23fe3b9"
+          "go1.26.1.linux-arm64.tar.gz",
+          "a290581cfe4fe28ddd737dde3095f3dbeb7f2e4065cab4eae44dfc53b760c2f7"
         ],
         "linux_armv6l": [
-          "go1.25.5.linux-armv6l.tar.gz",
-          "0b27e3dec8d04899d6941586d2aa2721c3dee67c739c1fc1b528188f3f6e8ab5"
+          "go1.26.1.linux-armv6l.tar.gz",
+          "c9937198994dc173b87630a94a0d323442bef81bf7589b1170d55a8ebf759bda"
         ],
         "linux_loong64": [
-          "go1.25.5.linux-loong64.tar.gz",
-          "0be2f27172a85de1b9c0c7f324832023b177d07cfa04a55dc67a3cc965fe969e"
+          "go1.26.1.linux-loong64.tar.gz",
+          "922b0f308771ce7e162f6c14a9d4bc86db329eaacf6db875e967ad7e5a6b065c"
         ],
         "linux_mips": [
-          "go1.25.5.linux-mips.tar.gz",
-          "0e7c387a6914c81b53278f023da2004e17d8d8e851749cdb5df15ad59e54ff3e"
+          "go1.26.1.linux-mips.tar.gz",
+          "8711f0396539d9051f27b7743c69ab48359dea75cfaa37b8c70b6ddf6b5d8259"
         ],
         "linux_mips64": [
-          "go1.25.5.linux-mips64.tar.gz",
-          "32ef8f4c4896c1e88dcbbf79c353d3e46dc38410e649327ee47e073e3326b06f"
+          "go1.26.1.linux-mips64.tar.gz",
+          "bbe2604bdf51e08d6386da7632f07379f88f31b2431ae71839a7064201a8ffd3"
         ],
         "linux_mips64le": [
-          "go1.25.5.linux-mips64le.tar.gz",
-          "437dc493b3ce97a65e7abc7e8ecb935f504b4805aff749baba219841bd970335"
+          "go1.26.1.linux-mips64le.tar.gz",
+          "1d97c7293a9760afb4a6e02d19e627d7eecea75b4f06096fd39b7977e4830b96"
         ],
         "linux_mipsle": [
-          "go1.25.5.linux-mipsle.tar.gz",
-          "675cd3e0cb7d9131602a0de06f5471ce969fd95d388baf1ec05106a1cdeb20b6"
+          "go1.26.1.linux-mipsle.tar.gz",
+          "2051d0dc77d8e35aaab39236ae1f913098bbee493c7ed6a6281a8dd5dc1e5db7"
         ],
         "linux_ppc64": [
-          "go1.25.5.linux-ppc64.tar.gz",
-          "a2159b254b025a816673365db565b3bd64f99fb185eb3f4cedabbf992097304d"
+          "go1.26.1.linux-ppc64.tar.gz",
+          "a14f56b7483c3829e7eb92766956b0b7c3cbb21d055d31c3d327a15baf5535c6"
         ],
         "linux_ppc64le": [
-          "go1.25.5.linux-ppc64le.tar.gz",
-          "f0904b647b5b8561efc5d48bb59a34f2b7996afab83ccd41c93b1aeb2c0067e4"
+          "go1.26.1.linux-ppc64le.tar.gz",
+          "f56eed002998f5f51fa07fd4ed0c5de5e02d51cec7a4007f771c7576620d9d45"
         ],
         "linux_riscv64": [
-          "go1.25.5.linux-riscv64.tar.gz",
-          "05de84b319bc91b9cecbc6bf8eb5fcd814cf8a9d16c248d293dbd96f6cc0151b"
+          "go1.26.1.linux-riscv64.tar.gz",
+          "56f8a63ae986c75e91001d65e17648564a10f0d2b18d696d13c91e459da1abd4"
         ],
         "linux_s390x": [
-          "go1.25.5.linux-s390x.tar.gz",
-          "a5d0a72b0dfd57f9c2c0cdd8b7e0f401e0afb9e8c304d3410f9b0982ce0953da"
+          "go1.26.1.linux-s390x.tar.gz",
+          "60fe623ef63e6338c055ec0e0e3f4fa85c97a056de2d2f6ee38591e2bfa9cdde"
         ],
         "netbsd_386": [
-          "go1.25.5.netbsd-386.tar.gz",
-          "57e79e72d1110954c6567082137f0228c46eb4d612211b3bf48dadb6a27eeaa2"
+          "go1.26.1.netbsd-386.tar.gz",
+          "158b816ce02a2a8cb07aca558bd332ba3b6f56d3b873f48979231f8beaa458a1"
         ],
         "netbsd_amd64": [
-          "go1.25.5.netbsd-amd64.tar.gz",
-          "d6062fa06c33613be60436b3e6422f2de43c28350bb30dbbc459782985eea7bd"
+          "go1.26.1.netbsd-amd64.tar.gz",
+          "42bf3dba3d2c023fb7cce66806e300d389951b2ba50484eb6a2d8cdb8baa8b50"
         ],
         "netbsd_arm": [
-          "go1.25.5.netbsd-arm.tar.gz",
-          "457d844df4aa6cd51616b2334e378cc295ee7bcca1cb21869adfc16f5f379bfd"
+          "go1.26.1.netbsd-arm.tar.gz",
+          "7107542cc768b1bdf713e33e7034dd2a5ca98e7357643c2c9695c6be5176a590"
         ],
         "netbsd_arm64": [
-          "go1.25.5.netbsd-arm64.tar.gz",
-          "5030511891f670dba65a6d8f15e687f623030ac5b63661a423a7dad53990b634"
+          "go1.26.1.netbsd-arm64.tar.gz",
+          "498845f0c6b5eb3136c1a21b87940e55a039639f0757b91016172e67ce899032"
         ],
         "openbsd_386": [
-          "go1.25.5.openbsd-386.tar.gz",
-          "27cba5feeedfb08dea2770420c6024d7ea72eedad08132a9759c0f05f66f2486"
+          "go1.26.1.openbsd-386.tar.gz",
+          "aba9d96b620eac5a3b47c0e58dc2a2d773c365991a6e1a9b681b8c77542adbed"
         ],
         "openbsd_amd64": [
-          "go1.25.5.openbsd-amd64.tar.gz",
-          "c873e93f6bd125a23b359914ba34d62e6af21111b06c14ce344b724aa1ef933b"
+          "go1.26.1.openbsd-amd64.tar.gz",
+          "8801baa1cc9d221b863b005555ba3c6cbd27fb50b651f7e31ea129d0ada27577"
         ],
         "openbsd_arm": [
-          "go1.25.5.openbsd-arm.tar.gz",
-          "e5a8cc469c66248bc2031327e66a4ad48a8f379435677386db52ef1aa7b2b0e2"
+          "go1.26.1.openbsd-arm.tar.gz",
+          "cdeb25b4d496c3e6610d86292af8c2699bca40cfdad27dd6366ea032e29f233b"
         ],
         "openbsd_arm64": [
-          "go1.25.5.openbsd-arm64.tar.gz",
-          "cdd655fa0e15bc839d0c353bfb728b8d22a8012e54a11e297be919c3cf7ad866"
+          "go1.26.1.openbsd-arm64.tar.gz",
+          "398f0074552368b0f8d874712a69bb4c999d16edaceaa31ff7dde735f524e815"
         ],
         "openbsd_ppc64": [
-          "go1.25.5.openbsd-ppc64.tar.gz",
-          "a149370fda34ce27fa78a452248f6f2040fe5ab955dce246d4d92de2c2d511c1"
+          "go1.26.1.openbsd-ppc64.tar.gz",
+          "74e95fa65c22cd2ab09a69532517bac51da5a66827766abd721f20a4fd9120dc"
         ],
         "openbsd_riscv64": [
-          "go1.25.5.openbsd-riscv64.tar.gz",
-          "be96cf8460011088cb75b330357796ecf1ac2ffffac77a3d1f798cbd7e6a2bc0"
+          "go1.26.1.openbsd-riscv64.tar.gz",
+          "1a78ed5f05959bda1a7feee108bb96fd46ca50f8f8ff60484fef0b6436bf36c0"
         ],
         "plan9_386": [
-          "go1.25.5.plan9-386.tar.gz",
-          "a3926108324c4b161080b03cd941db58090fba1194610093ee5716ee98997287"
+          "go1.26.1.plan9-386.tar.gz",
+          "214a665bbf5204caa1111a15a9607b3f0057ea9721e0dafbd5a71303de0708c4"
         ],
         "plan9_amd64": [
-          "go1.25.5.plan9-amd64.tar.gz",
-          "f171e529236b850ed4a1e714c317dddcf46855b575d9d018c654cf78b3ea1a2e"
+          "go1.26.1.plan9-amd64.tar.gz",
+          "c6b0bd3c0f0f4c62191c665a27df9f79470572ad29ecf6064368f3bde43c14bc"
         ],
         "plan9_arm": [
-          "go1.25.5.plan9-arm.tar.gz",
-          "aaf285e49f39717029f4759c0f9b2860dbf23c20fb659122006ba1e145643721"
+          "go1.26.1.plan9-arm.tar.gz",
+          "9caf03c5455fe14dd622cba54edc4655a895e302f09e34a6dd19c4ebc7c53786"
         ],
         "solaris_amd64": [
-          "go1.25.5.solaris-amd64.tar.gz",
-          "fb61c56ca80a2e1e5f74609ded64546166a5ab431c0d581ce718310cf27f6b9f"
+          "go1.26.1.solaris-amd64.tar.gz",
+          "e9d67570e05e43120692be78bf7497a22ff413526f8d6b7378bba9607a151b5b"
         ],
         "windows_386": [
-          "go1.25.5.windows-386.zip",
-          "a593393ea7715ffd315158f622a76226c3a4c4a0a6f92b1aeae03d7380cc06a3"
+          "go1.26.1.windows-386.zip",
+          "6a26b7ce038d96d2b3457ea4933667fb85c896411860216daf6ea17ecd4b25c5"
         ],
         "windows_amd64": [
-          "go1.25.5.windows-amd64.zip",
-          "ae756cce1cb80c819b4fe01b0353807178f532211b47f72d7fa77949de054ebb"
+          "go1.26.1.windows-amd64.zip",
+          "9b68112c913f45b7aebbf13c036721264bbba7e03a642f8f7490c561eebd1ecc"
         ],
         "windows_arm64": [
-          "go1.25.5.windows-arm64.zip",
-          "55a94a423a6b8f3ac2ac4d05a6e44d7760c6520a2c6dcef7425f6bac79c4eece"
+          "go1.26.1.windows-arm64.zip",
+          "c17e09676be0faad3cbed1c81bb02f38fb73e2f93d048571cc13730fe23f2d5b"
         ]
       }
     }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openconfig/bootz
 
-go 1.24.0
-
-toolchain go1.25.5
+go 1.26.1
 
 require (
 	github.com/coredhcp/coredhcp v0.0.0-20260112190756-6b627b2954a2

--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -242,40 +242,41 @@ func (m *InMemoryEntityManager) SetStatus(ctx context.Context, req *bpb.ReportSt
 	return nil
 }
 
-// Sign unmarshals the SignedResponse bytes then generates a signature from its Ownership Certificate private key.
-func (m *InMemoryEntityManager) Sign(ctx context.Context, resp *bpb.GetBootstrapDataResponse, chassis *types.Chassis) error {
+// Sign generates a signature over the input data using its Ownership Certificate private key,
+// and returns the based64-encoded signature string, the Ownership Voucher, and the Ownership Certificate.
+func (m *InMemoryEntityManager) Sign(ctx context.Context, data []byte, chassis *types.Chassis) (string, []byte, []byte, error) {
+	if len(data) == 0 {
+		return "", nil, nil, status.Errorf(codes.InvalidArgument, "empty input data to sign")
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// Check if security artifacts are provided for signing.
 	if m.secArtifacts == nil {
-		return status.Errorf(codes.Internal, "security artifact is missing")
-	}
-	if len(resp.GetSerializedBootstrapData()) == 0 {
-		return status.Errorf(codes.InvalidArgument, "empty serialized bootstrap data")
+		return "", nil, nil, status.Errorf(codes.Internal, "security artifact is missing")
 	}
 
-	sig, err := signature.Sign(m.secArtifacts.OwnerCertPrivateKey, m.secArtifacts.OwnerCert.SignatureAlgorithm, resp.GetSerializedBootstrapData())
+	sig, err := signature.Sign(m.secArtifacts.OwnerCertPrivateKey, m.secArtifacts.OwnerCert.SignatureAlgorithm, data)
 	if err != nil {
-		return err
+		return "", nil, nil, err
 	}
-	resp.ResponseSignature = sig
+	log.Infof("Signature generated")
 
-	// Populate the OV
+	// Fetch the OV
 	ov, err := m.fetchOwnershipVoucher(chassis.ActiveSerial)
 	if err != nil {
-		return err
+		return "", nil, nil, err
 	}
-	resp.OwnershipVoucher = ov
-	log.Infof("OV populated")
+	log.Infof("OV fetched")
 
-	// Populate the OC
-	ocCMS, err := ownercertificate.GenerateCMS(m.secArtifacts.OwnerCert, m.secArtifacts.OwnerCertPrivateKey)
+	// Fetch the OC
+	oc, err := ownercertificate.GenerateCMS(m.secArtifacts.OwnerCert, m.secArtifacts.OwnerCertPrivateKey)
 	if err != nil {
-		return err
+		return "", nil, nil, err
 	}
-	resp.OwnershipCertificate = ocCMS
-	log.Infof("OC populated")
-	return nil
+	log.Infof("OC fetched")
+
+	return sig, ov, oc, nil
 }
 
 // ValidateIDevID verifies the authenticity and authorization of a device by validating its IDevID certificate.

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -312,7 +312,7 @@ func TestSign(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			err = em.Sign(ctx, test.resp, &test.chassis)
+			sigString, ov, oc, err := em.Sign(ctx, test.resp.GetSerializedBootstrapData(), &test.chassis)
 			if err != nil {
 				if test.wantErr {
 					t.Skip()
@@ -320,7 +320,7 @@ func TestSign(t *testing.T) {
 				t.Errorf("Sign() err = %v, want %v", err, test.wantErr)
 			}
 
-			sig, err := base64.StdEncoding.DecodeString(test.resp.GetResponseSignature())
+			sig, err := base64.StdEncoding.DecodeString(sigString)
 			if err != nil {
 				t.Errorf("unable to base64 decode: %v", err)
 			}
@@ -328,8 +328,8 @@ func TestSign(t *testing.T) {
 			if err != nil {
 				t.Errorf("Verify() err == %v, want %v", err, test.wantErr)
 			}
-			if !bytes.Equal(test.resp.GetOwnershipVoucher(), a.OV[test.chassis.ActiveSerial]) {
-				t.Errorf("Sign() ov = %v, want %v", test.resp.GetOwnershipVoucher(), a.OV[test.chassis.ActiveSerial])
+			if !bytes.Equal(ov, a.OV[test.chassis.ActiveSerial]) {
+				t.Errorf("Sign() ov = %v, want %v", ov, a.OV[test.chassis.ActiveSerial])
 			}
 			if test.wantOC {
 				wantOC, err := ownercertificate.GenerateCMS(a.OwnerCert, a.OwnerCertPrivateKey)
@@ -340,7 +340,7 @@ func TestSign(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unable to parse OC CMS message: %v", err)
 				}
-				gotCert, err := ownercertificate.Verify(test.resp.GetOwnershipCertificate(), nil)
+				gotCert, err := ownercertificate.Verify(oc, nil)
 				if err != nil {
 					t.Fatalf("unable to parse OC CMS message: %v", err)
 				}

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -404,7 +404,6 @@ func (s *Service) BootstrapStream(stream bpb.Bootstrap_BootstrapStreamServer) er
 
 // BootstrapStreamV1 implements the RPC handler for Streaming Bootz v1.0.
 func (s *Service) BootstrapStreamV1(stream bpb.Bootstrap_BootstrapStreamV1Server) error {
-	ctx := stream.Context()
 	session := &streamSessionV1{stream: stream, currentState: stateInitial, chassis: &types.Chassis{}}
 
 	for {
@@ -418,6 +417,7 @@ func (s *Service) BootstrapStreamV1(stream bpb.Bootstrap_BootstrapStreamV1Server
 			return err
 		}
 
+		var response *bpb.BootstrapStreamResponseV1
 		switch req := in.GetType().(type) {
 		case *bpb.BootstrapStreamRequestV1_BootstrapRequest:
 			log.Infof("=============================================================================")
@@ -426,34 +426,11 @@ func (s *Service) BootstrapStreamV1(stream bpb.Bootstrap_BootstrapStreamV1Server
 			if session.currentState != stateInitial {
 				return status.Errorf(codes.FailedPrecondition, "BootstrapRequest can only be sent as the first message")
 			}
-			bootstrapRequest := req.BootstrapRequest
-			session.clientNonce = bootstrapRequest.GetNonce()
-			log.Infof("Received initial BootstrapRequest: %+v", bootstrapRequest)
+			log.Infof("Received initial BootstrapRequest: %+v", req.BootstrapRequest)
+			session.clientNonce = req.BootstrapRequest.GetNonce()
 
-			chassis, err := initializeChassis(ctx, bootstrapRequest)
-			if err != nil {
-				return status.Errorf(codes.InvalidArgument, "failed to build entity lookup from request: %v", err)
-			}
-			session.chassis = chassis
-
-			switch idType := chassis.Identity.GetType().(type) {
-			case *bpb.Identity_IdevidCert:
-				log.Infof("Detected TPM 2.0 IDevID flow for device %s", chassis.ActiveSerial)
-				// TODO: logic to send the challenge
-				return status.Errorf(codes.Unimplemented, "TPM 2.0 IDevID flow not fully implemented")
-
-			case *bpb.Identity_Tpm20EkPub, *bpb.Identity_Tpm20PpkPub:
-				log.Infof("Detected TPM 2.0 EK/PPK flow for device %s", chassis.ActiveSerial)
-				// TODO: logic to send the challenge
-				return status.Errorf(codes.Unimplemented, "TPM 2.0 EK/PPK flow not fully implemented")
-
-			case *bpb.Identity_Tpm12EkPub:
-				log.Infof("Detected TPM 1.2 EK flow for device %s", chassis.ActiveSerial)
-				// TODO: logic to send the challenge
-				return status.Errorf(codes.Unimplemented, "TPM 1.2 EK flow not fully implemented")
-
-			default:
-				return status.Errorf(codes.InvalidArgument, "unsupported identity type: %T", idType)
+			if response, err = s.createChallengeRequest(session, req.BootstrapRequest); err != nil {
+				return err
 			}
 
 		case *bpb.BootstrapStreamRequestV1_ChallengeResponse_:
@@ -497,18 +474,102 @@ func (s *Service) BootstrapStreamV1(stream bpb.Bootstrap_BootstrapStreamV1Server
 			session.status = req.ReportStatusRequest
 
 			if session.currentState == stateInitial {
-				log.Info("Received ReportStatusRequest on a new stream. Starting re-authentication...")
-				// TODO: logic to send challenge again
+				log.Info("This is a new stream. Starting re-authentication...")
+				if response, err = s.createChallengeRequest(session, req.ReportStatusRequest); err != nil {
+					return err
+				}
+				session.currentState = stateReauthChallengeSent
+			} else {
+				// TODO: logic to update status
 				return status.Errorf(codes.Unimplemented, "Not yet implemented")
 			}
 
-			// TODO: logic to update status
-			return status.Errorf(codes.Unimplemented, "Not yet implemented")
-
 		default:
-			return status.Errorf(codes.InvalidArgument, "unexpected message type: %T", req)
+			return status.Errorf(codes.InvalidArgument, "unsupported message type: %T", req)
 		}
+
+		if err = stream.Send(response); err != nil {
+			return status.Errorf(codes.Internal, "failed to send BootstrapStreamResponseV1 message: %v", err)
+		}
+		log.Infof("Sent BootstrapStreamResponseV1 message to device %s", session.chassis.ActiveSerial)
 	}
+}
+
+// createChallengeRequest creates a challenge request message for Streaming Bootz v1.0.
+func (s *Service) createChallengeRequest(session *streamSessionV1, message proto.Message) (*bpb.BootstrapStreamResponseV1, error) {
+	var challengeRequest *bpb.BootstrapStreamResponseV1
+	ctx := session.stream.Context()
+	chassis, err := initializeChassis(ctx, message)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to initialize chassis from received message: %v", err)
+	}
+	if err = s.em.ResolveChassis(ctx, chassis); err != nil {
+		return nil, status.Errorf(codes.NotFound, "failed to resolve chassis: %v", err)
+	}
+	if !chassis.StreamingSupported {
+		return nil, status.Errorf(codes.Unimplemented, "streaming bootstrap is not supported for this device")
+	}
+	log.Infof("Resolved device %s with identity %T to hostname %s", chassis.ActiveSerial, chassis.Identity.GetType(), chassis.Hostname)
+	session.chassis = chassis
+
+	switch idType := chassis.Identity.GetType().(type) {
+	case *bpb.Identity_IdevidCert:
+		// Generate a random server nonce.
+		nonceBytes := make([]byte, 32)
+		if _, err = rand.Read(nonceBytes); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to generate server nonce: %v", err)
+		}
+		session.serverNonce = nonceBytes
+		challengeRequest = &bpb.BootstrapStreamResponseV1{
+			Type: &bpb.BootstrapStreamResponseV1_ChallengeRequest_{
+				ChallengeRequest: &bpb.BootstrapStreamResponseV1_ChallengeRequest{
+					Type: &bpb.BootstrapStreamResponseV1_ChallengeRequest_Tpm20Idevid{
+						Tpm20Idevid: &bpb.BootstrapStreamResponseV1_ChallengeRequest_ChallengeRequestTPM20IDevID{
+							Nonce: nonceBytes,
+						},
+					},
+				},
+			},
+		}
+
+	case *bpb.Identity_Tpm20EkPub, *bpb.Identity_Tpm20PpkPub:
+		// Generate a restricted HMAC key.
+		hmacPub, hmacSensitive, err := s.tpm20.GenerateRestrictedHMACKey()
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to generate a restricted HMAC key: %v", err)
+		}
+		// Wrap HMAC key to EK/PPK public key.
+		duplicate, inSymSeed, err := s.tpm20.WrapHMACKeytoRSAPublicKey(chassis.ActivePublicKey, hmacPub, hmacSensitive)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to wrap HMAC key to EK/PPK public key: %v", err)
+		}
+		session.hmacSensitive = hmacSensitive
+		challengeRequest = &bpb.BootstrapStreamResponseV1{
+			Type: &bpb.BootstrapStreamResponseV1_ChallengeRequest_{
+				ChallengeRequest: &bpb.BootstrapStreamResponseV1_ChallengeRequest{
+					Type: &bpb.BootstrapStreamResponseV1_ChallengeRequest_Tpm20Hmac{
+						Tpm20Hmac: &bpb.BootstrapStreamResponseV1_ChallengeRequest_ChallengeRequestTPM20HMAC{
+							HmacEncrypted: &epb.HMACChallenge{
+								HmacPubKey: tpm2.Marshal(tpm2.New2B(*hmacPub)),
+								Duplicate:  tpm2.Marshal(&tpm2.TPM2BPrivate{Buffer: duplicate}),
+								InSymSeed:  tpm2.Marshal(&tpm2.TPM2BEncryptedSecret{Buffer: inSymSeed}),
+							},
+						},
+					},
+				},
+			},
+		}
+
+	case *bpb.Identity_Tpm12EkPub:
+		// TODO: logic to create the challenge
+		return nil, status.Errorf(codes.Unimplemented, "TPM 1.2 EK flow not fully implemented")
+
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unsupported device identity type: %T", idType)
+	}
+
+	log.Infof("Created challenge request for device %s", chassis.ActiveSerial)
+	return challengeRequest, nil
 }
 
 // sendIdevidChallenge contains the logic for parsing an IDevID cert, and sending a nonce challenge.

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -16,8 +16,11 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto"
+	"crypto/ecdh"
+	"crypto/hpke"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -85,7 +88,7 @@ type EntityManager interface {
 	ResolveChassis(context.Context, *types.Chassis) error
 	GetBootstrapData(context.Context, *types.Chassis, string) (*bpb.BootstrapDataResponse, error)
 	SetStatus(context.Context, *bpb.ReportStatusRequest) error
-	Sign(context.Context, *bpb.GetBootstrapDataResponse, *types.Chassis) error
+	Sign(context.Context, []byte, *types.Chassis) (string, []byte, []byte, error)
 	ValidateIDevID(context.Context, *x509.Certificate, []byte, *types.Chassis) error
 }
 
@@ -113,7 +116,6 @@ type streamSessionV1 struct {
 	chassis       *types.Chassis           // Store chassis info for later stages
 	status        *bpb.ReportStatusRequest // Store status for later stages
 	clientNonce   string                   // client nonce from bootstrap request
-	idevidCert    *x509.Certificate        // For IDevID flow
 	serverNonce   []byte                   // For TPM 2.0 with IDevID nonce challenge
 	hmacSensitive *tpm2.TPMTSensitive      // For TPM 2.0 without IDevID HMAC challenge
 }
@@ -201,9 +203,13 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bpb.GetBootstrapDat
 		log.Infof("=============================================================================")
 		log.Infof("====================== Signing the response with nonce ======================")
 		log.Infof("=============================================================================")
-		if err := s.em.Sign(ctx, resp, chassis); err != nil {
+		sig, ov, oc, err := s.em.Sign(ctx, signedResponseBytes, chassis)
+		if err != nil {
 			return nil, err
 		}
+		resp.ResponseSignature = sig
+		resp.OwnershipVoucher = ov
+		resp.OwnershipCertificate = oc
 		log.Infof("Signed with nonce")
 	}
 	log.Infof("Returning response")
@@ -350,11 +356,15 @@ func (s *Service) BootstrapStream(stream bpb.Bootstrap_BootstrapStreamServer) er
 			if err != nil {
 				return status.Errorf(codes.Internal, "failed to serialize bootstrap data: %v", err)
 			}
+			sig, ov, oc, err := s.em.Sign(ctx, serializedSignedData, session.chassis)
+			if err != nil {
+				return status.Errorf(codes.Internal, "failed to sign bootstrap data: %v", err)
+			}
 			bootstrapRespForSigning := &bpb.GetBootstrapDataResponse{
 				SerializedBootstrapData: serializedSignedData,
-			}
-			if err := s.em.Sign(ctx, bootstrapRespForSigning, session.chassis); err != nil {
-				return status.Errorf(codes.Internal, "failed to sign bootstrap data: %v", err)
+				ResponseSignature:       sig,
+				OwnershipVoucher:        ov,
+				OwnershipCertificate:    oc,
 			}
 
 			// Send the bootstrap data to the device.
@@ -432,6 +442,7 @@ func (s *Service) BootstrapStreamV1(stream bpb.Bootstrap_BootstrapStreamV1Server
 			if response, err = s.createChallengeRequest(session, req.BootstrapRequest); err != nil {
 				return err
 			}
+			session.currentState = stateChallengeSent
 
 		case *bpb.BootstrapStreamRequestV1_ChallengeResponse_:
 			log.Infof("=============================================================================")
@@ -443,13 +454,41 @@ func (s *Service) BootstrapStreamV1(stream bpb.Bootstrap_BootstrapStreamV1Server
 			log.Infof("Received ChallengeResponse from device %s", session.chassis.ActiveSerial)
 			challengeResponse := req.ChallengeResponse
 
+			var serializedTransportKey []byte
 			switch challengeType := challengeResponse.GetType().(type) {
 			case *bpb.BootstrapStreamRequestV1_ChallengeResponse_Tpm20Idevid:
 				if len(session.serverNonce) == 0 {
 					return status.Errorf(codes.InvalidArgument, "received unexpected TPM20IDevID challenge response")
 				}
-				// TODO: logic to verify the challenge response
-				return status.Errorf(codes.Unimplemented, "Not yet implemented")
+				// Verify IDevID certificate.
+				var certDER, intermediates []byte
+				var pemBlock *pem.Block
+				idevid := session.chassis.Identity.GetIdevidCert()
+				if certDER, err = base64.StdEncoding.DecodeString(idevid); err != nil {
+					// If we can't base64 decode the cert, it might be a PEM-encoded cert chain.
+					// Find the first (leaf) cert in the PEM block, then decode it to a DER string.
+					if pemBlock, intermediates = pem.Decode([]byte(idevid)); pemBlock == nil {
+						return status.Errorf(codes.InvalidArgument, "idevid_cert is not a valid PEM block or base64 encoded DER cert")
+					}
+					certDER = pemBlock.Bytes
+				}
+				cert, err := x509.ParseCertificate(certDER)
+				if err != nil {
+					return status.Errorf(codes.InvalidArgument, "failed to parse idevid_cert: %v", err)
+				}
+				if err = s.em.ValidateIDevID(stream.Context(), cert, intermediates, session.chassis); err != nil {
+					log.Errorf("Tpm20Idevid challenge certificate verification failed for device %s, error: %v", session.chassis.ActiveSerial, err)
+					return status.Errorf(codes.InvalidArgument, "failed to validate idevid_cert: %v", err)
+				}
+				log.Infof("Successfully validated IDevID cert for %s", cert.Subject.CommonName)
+				// Verify IDevID signature.
+				serializedTransportKey = challengeResponse.GetTpm20Idevid().GetSerializedTransportKey()
+				sig := challengeResponse.GetTpm20Idevid().GetSignature()
+				if err = signature.Verify(cert, serializedTransportKey, sig); err != nil {
+					log.Errorf("Tpm20Idevid challenge signature verification failed for device %s. signature: %v, error: %v", session.chassis.ActiveSerial, sig, err)
+					return status.Errorf(codes.InvalidArgument, "Tpm20Idevid challenge signature verification failed: %v", err)
+				}
+				log.Infof("Tpm20Idevid challenge verification succeeded for device %s", session.chassis.ActiveSerial)
 
 			case *bpb.BootstrapStreamRequestV1_ChallengeResponse_Tpm20Hmac:
 				if session.hmacSensitive == nil {
@@ -465,6 +504,79 @@ func (s *Service) BootstrapStreamV1(stream bpb.Bootstrap_BootstrapStreamV1Server
 			default:
 				return status.Errorf(codes.InvalidArgument, "unsupported challenge response type: %T", challengeType)
 			}
+
+			var transportKey bpb.TransportKey
+			if err = proto.Unmarshal(serializedTransportKey, &transportKey); err != nil {
+				return status.Errorf(codes.InvalidArgument, "failed to deserialize TransportKey message: %v", err)
+			}
+			// Verify server nonce if applicable.
+			if len(session.serverNonce) != 0 && !bytes.Equal(session.serverNonce, transportKey.GetNonce()) {
+				log.Errorf("Tpm20Idevid challenge nonce does not match, expected %x, received: %x", session.serverNonce, transportKey.GetNonce())
+				return status.Errorf(codes.InvalidArgument, "Tpm20Idevid challenge nonce does not match")
+			}
+			// Check whether this is re-authentication for status report.
+			if session.currentState == stateReauthChallengeSent {
+				log.Infof("Created status report acknowledgement after re-authentication for device %s", session.chassis.ActiveSerial)
+				// TODO: logic to update status
+				return status.Errorf(codes.Unimplemented, "Acknowledgement for status report is not yet implemented")
+			} else {
+				// Otherwise fetch the bootstrap data.
+				var bootstrapData []*bpb.BootstrapDataResponse
+				for _, v := range session.chassis.Serials {
+					log.Infof("Fetching bootstrap data for serial number: %s", v)
+					data, err := s.em.GetBootstrapData(stream.Context(), session.chassis, v)
+					if err != nil {
+						return status.Errorf(codes.Internal, "failed to get bootstrap data for serial number %s: %v", v, err)
+					}
+					bootstrapData = append(bootstrapData, data)
+				}
+				serializedBootstrapData, err := proto.Marshal(&bpb.BootstrapDataSigned{
+					Responses: bootstrapData,
+					Nonce:     session.clientNonce,
+				})
+				if err != nil {
+					return status.Errorf(codes.Internal, "failed to serialize BootstrapDataSigned message: %v", err)
+				}
+				// Encrypt the bootstrap data.
+				switch transportKey.GetCipherSuite() {
+				case bpb.HPKECipherSuite_HPKE_CIPHER_SUITE_X25519_HKDF_SHA256_HKDF_SHA256_AES_256_GCM:
+					kem, kdf, aead := hpke.DHKEM(ecdh.X25519()), hpke.HKDFSHA256(), hpke.AES256GCM()
+					publicKey, err := kem.NewPublicKey(transportKey.GetPublicKey())
+					if err != nil {
+						return status.Errorf(codes.InvalidArgument, "failed to deserialize HPKE public key: %v", err)
+					}
+					encapsulatedKey, sender, err := hpke.NewSender(publicKey, kdf, aead, nil)
+					if err != nil {
+						return status.Errorf(codes.Internal, "failed to create HPKE sender: %v", err)
+					}
+					cipherText, err := sender.Seal(nil, serializedBootstrapData)
+					if err != nil {
+						return status.Errorf(codes.Internal, "failed to encrypt bootstrap data: %v", err)
+					}
+					response = &bpb.BootstrapStreamResponseV1{
+						Type: &bpb.BootstrapStreamResponseV1_BootstrapResponse{
+							BootstrapResponse: &bpb.StreamBootstrapDataResponse{
+								EncryptedSerializedBootstrapData: cipherText,
+								EncapsulatedKey:                  encapsulatedKey,
+							},
+						},
+					}
+				case bpb.HPKECipherSuite_HPKE_CIPHER_SUITE_NONE:
+					return status.Errorf(codes.InvalidArgument, "HPKE cipher suite can not be none")
+				default:
+					return status.Errorf(codes.InvalidArgument, "unsupported HPKE cipher suite enum: %v", transportKey.GetCipherSuite())
+				}
+				// Sign the bootstrap data.
+				sig, ov, oc, err := s.em.Sign(stream.Context(), response.GetBootstrapResponse().GetEncryptedSerializedBootstrapData(), session.chassis)
+				if err != nil {
+					return status.Errorf(codes.Internal, "failed to sign bootstrap data: %v", err)
+				}
+				response.GetBootstrapResponse().ResponseSignature = sig
+				response.GetBootstrapResponse().OwnershipVoucher = ov
+				response.GetBootstrapResponse().OwnershipCertificate = oc
+				log.Infof("Created bootstrap data for device %s", session.chassis.ActiveSerial)
+			}
+			session.currentState = stateAttested
 
 		case *bpb.BootstrapStreamRequestV1_ReportStatusRequest:
 			log.Infof("=============================================================================")

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -480,6 +480,138 @@ func TestBootstrapStream(t *testing.T) {
 	}
 }
 
+func TestBootstrapStreamV1(t *testing.T) {
+	_, deviceCert := createTestCertificate(t, "test-device", "test-serial-123")
+	idevidCert := base64.StdEncoding.EncodeToString(deviceCert)
+	ekPub := &rsa.PublicKey{N: big.NewInt(123456789), E: 65537}
+	idIdevid := &bpb.Identity{Type: &bpb.Identity_IdevidCert{IdevidCert: idevidCert}}
+	idTPM20EK := &bpb.Identity{Type: &bpb.Identity_Tpm20EkPub{Tpm20EkPub: []byte{}}}
+	em := &mockEntityManager{
+		resolveChassisResp:   &types.Chassis{StreamingSupported: true, ActivePublicKey: ekPub, ActivePublicKeyType: epb.Key_KEY_EK},
+		getBootstrapDataResp: &bpb.BootstrapDataResponse{BootConfig: &bpb.BootConfig{VendorConfig: []byte("test-vendor-config")}},
+	}
+	initialReq := &bpb.BootstrapStreamRequestV1{
+		Type: &bpb.BootstrapStreamRequestV1_BootstrapRequest{
+			BootstrapRequest: &bpb.GetBootstrapDataRequest{
+				ChassisDescriptor: &bpb.ChassisDescriptor{SerialNumber: "test-serial-123"},
+				ControlCardState:  &bpb.ControlCardState{SerialNumber: "test-serial-123"},
+			},
+		},
+	}
+	statusReq := &bpb.BootstrapStreamRequestV1{
+		Type: &bpb.BootstrapStreamRequestV1_ReportStatusRequest{
+			ReportStatusRequest: &bpb.ReportStatusRequest{
+				States: []*bpb.ControlCardState{
+					{SerialNumber: "test-serial-123"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		em        *mockEntityManager
+		tpm       *mockTPM20Utils
+		req       *bpb.BootstrapStreamRequestV1
+		id        *bpb.Identity
+		wantCodes []codes.Code
+	}{
+		{
+			name:      "Missing Identity - Invalid Argument",
+			em:        &mockEntityManager{},
+			req:       initialReq,
+			wantCodes: []codes.Code{codes.InvalidArgument},
+		},
+		{
+			name:      "IDevID Flow Success - Initial Bootstrap Request Only",
+			em:        em,
+			req:       initialReq,
+			id:        idIdevid,
+			wantCodes: []codes.Code{codes.OK},
+		},
+		{
+			name:      "TPM 2.0 EK Flow Success - Initial Bootstrap Request Only",
+			em:        em,
+			tpm:       &mockTPM20Utils{},
+			req:       initialReq,
+			id:        idTPM20EK,
+			wantCodes: []codes.Code{codes.OK},
+		},
+		{
+			name:      "IDevID Flow Success - Initial Status Report Only",
+			em:        em,
+			req:       statusReq,
+			id:        idIdevid,
+			wantCodes: []codes.Code{codes.OK},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := New(test.em, test.tpm)
+			srv := grpc.NewServer(grpc.Creds(insecure.NewCredentials()))
+			bpb.RegisterBootstrapServer(srv, s)
+			addr := startTestServer(t, srv)
+			conn := createTestClient(t, addr, nil)
+			cli := bpb.NewBootstrapClient(conn)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			stream, err := cli.BootstrapStreamV1(ctx)
+			if err != nil {
+				t.Fatalf("BootstrapStreamV1() failed: %v", err)
+			}
+
+			for step, wantCode := range test.wantCodes {
+				var message *bpb.BootstrapStreamRequestV1
+
+				// TODO: Add testing for further steps once handling code is implemented.
+				switch step {
+				case 0: // Send Challenge Request
+					message = proto.Clone(test.req).(*bpb.BootstrapStreamRequestV1)
+				}
+
+				if test.id != nil {
+					switch reqType := message.Type.(type) {
+					case *bpb.BootstrapStreamRequestV1_BootstrapRequest:
+						reqType.BootstrapRequest.Identity = test.id
+					case *bpb.BootstrapStreamRequestV1_ReportStatusRequest:
+						reqType.ReportStatusRequest.Identity = test.id
+					}
+				}
+				if err := stream.Send(message); err != nil {
+					t.Fatalf("stream.Send(%v) failed: %v", message, err)
+				}
+				resp, err := stream.Recv()
+				stat, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("failed to extract status code from error: %v", err)
+				}
+
+				if stat.Code() != wantCode {
+					t.Errorf("[Step %v] stream.Recv() got error code %v, want %v:", step, stat.Code(), wantCode)
+				}
+				if err != nil {
+					return
+				}
+
+				// TODO: Add checking for further steps once handling code is implemented.
+				switch step {
+				case 0: // Received Challenge Response
+					if resp.GetChallengeRequest() == nil {
+						t.Errorf("received blank challenge request")
+					}
+				}
+			}
+
+			stream.CloseSend()
+			_, err = stream.Recv()
+			if err != io.EOF {
+				t.Errorf("Expected EOF after final response, got %v", err)
+			}
+		})
+	}
+}
+
 func peerAddressContext(t *testing.T, address string) context.Context {
 	t.Helper()
 	return peer.NewContext(context.Background(), &peer.Peer{

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -14,8 +14,11 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto"
+	"crypto/ecdh"
+	"crypto/hpke"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -46,6 +49,14 @@ import (
 	bpb "github.com/openconfig/bootz/proto/bootz"
 )
 
+var (
+	testOV            = []byte("test-ov")
+	testOC            = []byte("test-oc")
+	testSig           = "test-signature"
+	testNonce         = "test-client-nonce"
+	testBootstrapData = &bpb.BootstrapDataResponse{BootConfig: &bpb.BootConfig{VendorConfig: []byte("test-vendor-config")}}
+)
+
 // Mock EntityManager for testing purposes.
 type mockEntityManager struct {
 	resolveChassisResp   *types.Chassis
@@ -71,8 +82,8 @@ func (m *mockEntityManager) GetBootstrapData(context.Context, *types.Chassis, st
 func (m *mockEntityManager) SetStatus(context.Context, *bpb.ReportStatusRequest) error {
 	return m.setStatusErr
 }
-func (m *mockEntityManager) Sign(context.Context, *bpb.GetBootstrapDataResponse, *types.Chassis) error {
-	return m.signErr
+func (m *mockEntityManager) Sign(context.Context, []byte, *types.Chassis) (string, []byte, []byte, error) {
+	return testSig, testOV, testOC, m.signErr
 }
 func (m *mockEntityManager) ValidateIDevID(context.Context, *x509.Certificate, []byte, *types.Chassis) error {
 	return m.signErr
@@ -171,10 +182,8 @@ func TestBootstrapStream(t *testing.T) {
 	goodCert := base64.StdEncoding.EncodeToString(goodCertDER)
 	ekPub := &rsa.PublicKey{N: big.NewInt(123456789), E: 65537}
 	em := &mockEntityManager{
-		resolveChassisResp: &types.Chassis{StreamingSupported: true, ActivePublicKey: ekPub, ActivePublicKeyType: epb.Key_KEY_EK},
-		getBootstrapDataResp: &bpb.BootstrapDataResponse{
-			BootConfig: &bpb.BootConfig{VendorConfig: []byte("test-vendor-config")},
-		},
+		resolveChassisResp:   &types.Chassis{StreamingSupported: true, ActivePublicKey: ekPub, ActivePublicKeyType: epb.Key_KEY_EK},
+		getBootstrapDataResp: testBootstrapData,
 	}
 	initialReq := &bpb.BootstrapStreamRequest{
 		Type: &bpb.BootstrapStreamRequest_BootstrapRequest{
@@ -247,11 +256,9 @@ func TestBootstrapStream(t *testing.T) {
 		{
 			name: "IDevID Flow with Failing Status Report",
 			em: &mockEntityManager{
-				resolveChassisResp: &types.Chassis{StreamingSupported: true},
-				getBootstrapDataResp: &bpb.BootstrapDataResponse{
-					BootConfig: &bpb.BootConfig{VendorConfig: []byte("test-vendor-config")},
-				},
-				setStatusErr: status.Errorf(codes.Internal, "db error"),
+				resolveChassisResp:   &types.Chassis{StreamingSupported: true},
+				getBootstrapDataResp: testBootstrapData,
+				setStatusErr:         status.Errorf(codes.Internal, "db error"),
 			},
 			req:          initialReq,
 			id:           idIdevid,
@@ -481,20 +488,33 @@ func TestBootstrapStream(t *testing.T) {
 }
 
 func TestBootstrapStreamV1(t *testing.T) {
-	_, deviceCert := createTestCertificate(t, "test-device", "test-serial-123")
+	deviceKey, deviceCert := createTestCertificate(t, "test-device", "test-serial-123")
 	idevidCert := base64.StdEncoding.EncodeToString(deviceCert)
 	ekPub := &rsa.PublicKey{N: big.NewInt(123456789), E: 65537}
 	idIdevid := &bpb.Identity{Type: &bpb.Identity_IdevidCert{IdevidCert: idevidCert}}
 	idTPM20EK := &bpb.Identity{Type: &bpb.Identity_Tpm20EkPub{Tpm20EkPub: []byte{}}}
+	hpkeKey, err := hpke.DHKEM(ecdh.X25519()).GenerateKey()
+	if err != nil {
+		t.Fatalf("Failed to generate HPKE key: %v", err)
+	}
+	transportKey := &bpb.TransportKey{
+		CipherSuite: bpb.HPKECipherSuite_HPKE_CIPHER_SUITE_X25519_HKDF_SHA256_HKDF_SHA256_AES_256_GCM,
+		PublicKey:   hpkeKey.PublicKey().Bytes(),
+	}
+	bootstrapData := &bpb.BootstrapDataSigned{
+		Responses: []*bpb.BootstrapDataResponse{testBootstrapData},
+		Nonce:     testNonce,
+	}
 	em := &mockEntityManager{
 		resolveChassisResp:   &types.Chassis{StreamingSupported: true, ActivePublicKey: ekPub, ActivePublicKeyType: epb.Key_KEY_EK},
-		getBootstrapDataResp: &bpb.BootstrapDataResponse{BootConfig: &bpb.BootConfig{VendorConfig: []byte("test-vendor-config")}},
+		getBootstrapDataResp: testBootstrapData,
 	}
 	initialReq := &bpb.BootstrapStreamRequestV1{
 		Type: &bpb.BootstrapStreamRequestV1_BootstrapRequest{
 			BootstrapRequest: &bpb.GetBootstrapDataRequest{
 				ChassisDescriptor: &bpb.ChassisDescriptor{SerialNumber: "test-serial-123"},
 				ControlCardState:  &bpb.ControlCardState{SerialNumber: "test-serial-123"},
+				Nonce:             testNonce,
 			},
 		},
 	}
@@ -523,11 +543,11 @@ func TestBootstrapStreamV1(t *testing.T) {
 			wantCodes: []codes.Code{codes.InvalidArgument},
 		},
 		{
-			name:      "IDevID Flow Success - Initial Bootstrap Request Only",
+			name:      "IDevID Flow Success - Full Process",
 			em:        em,
 			req:       initialReq,
 			id:        idIdevid,
-			wantCodes: []codes.Code{codes.OK},
+			wantCodes: []codes.Code{codes.OK, codes.OK},
 		},
 		{
 			name:      "TPM 2.0 EK Flow Success - Initial Bootstrap Request Only",
@@ -538,7 +558,7 @@ func TestBootstrapStreamV1(t *testing.T) {
 			wantCodes: []codes.Code{codes.OK},
 		},
 		{
-			name:      "IDevID Flow Success - Initial Status Report Only",
+			name:      "IDevID Flow Success - Status Report in New Stream",
 			em:        em,
 			req:       statusReq,
 			id:        idIdevid,
@@ -561,27 +581,58 @@ func TestBootstrapStreamV1(t *testing.T) {
 				t.Fatalf("BootstrapStreamV1() failed: %v", err)
 			}
 
+			var request *bpb.BootstrapStreamRequestV1
+			var response *bpb.BootstrapStreamResponseV1
 			for step, wantCode := range test.wantCodes {
-				var message *bpb.BootstrapStreamRequestV1
-
 				// TODO: Add testing for further steps once handling code is implemented.
 				switch step {
-				case 0: // Send Challenge Request
-					message = proto.Clone(test.req).(*bpb.BootstrapStreamRequestV1)
+				case 0: // Send Bootstrap Request.
+					request = proto.Clone(test.req).(*bpb.BootstrapStreamRequestV1)
+				case 1: // Send Challenge Response.
+					switch reqType := response.GetChallengeRequest().Type.(type) {
+					case *bpb.BootstrapStreamResponseV1_ChallengeRequest_Tpm20Idevid:
+						msg := proto.Clone(transportKey).(*bpb.TransportKey)
+						msg.Nonce = reqType.Tpm20Idevid.GetNonce()
+						serializedMsg, err := proto.Marshal(msg)
+						if err != nil {
+							t.Fatalf("Failed to serialize transport key message: %v", err)
+						}
+						hasher := sha256.New()
+						hasher.Write(serializedMsg)
+						hash := hasher.Sum(nil)
+						sig, err := rsa.SignPKCS1v15(rand.Reader, deviceKey, crypto.SHA256, hash)
+						if err != nil {
+							t.Fatalf("Failed to sign transport key: %v", err)
+						}
+						request = &bpb.BootstrapStreamRequestV1{
+							Type: &bpb.BootstrapStreamRequestV1_ChallengeResponse_{
+								ChallengeResponse: &bpb.BootstrapStreamRequestV1_ChallengeResponse{
+									Type: &bpb.BootstrapStreamRequestV1_ChallengeResponse_Tpm20Idevid{
+										Tpm20Idevid: &bpb.BootstrapStreamRequestV1_ChallengeResponse_ChallengeResponseTPM20IDevID{
+											SerializedTransportKey: serializedMsg,
+											Signature:              sig,
+										},
+									},
+								},
+							},
+						}
+					case *bpb.BootstrapStreamResponseV1_ChallengeRequest_Tpm20Hmac:
+					case *bpb.BootstrapStreamResponseV1_ChallengeRequest_Tpm12Ek:
+					}
 				}
 
 				if test.id != nil {
-					switch reqType := message.Type.(type) {
+					switch reqType := request.Type.(type) {
 					case *bpb.BootstrapStreamRequestV1_BootstrapRequest:
 						reqType.BootstrapRequest.Identity = test.id
 					case *bpb.BootstrapStreamRequestV1_ReportStatusRequest:
 						reqType.ReportStatusRequest.Identity = test.id
 					}
 				}
-				if err := stream.Send(message); err != nil {
-					t.Fatalf("stream.Send(%v) failed: %v", message, err)
+				if err := stream.Send(request); err != nil {
+					t.Fatalf("stream.Send(%v) failed: %v", request, err)
 				}
-				resp, err := stream.Recv()
+				response, err = stream.Recv()
 				stat, ok := status.FromError(err)
 				if !ok {
 					t.Fatalf("failed to extract status code from error: %v", err)
@@ -596,9 +647,47 @@ func TestBootstrapStreamV1(t *testing.T) {
 
 				// TODO: Add checking for further steps once handling code is implemented.
 				switch step {
-				case 0: // Received Challenge Response
-					if resp.GetChallengeRequest() == nil {
-						t.Errorf("received blank challenge request")
+				case 0: // Received Challenge Request.
+					if response.GetChallengeRequest() == nil {
+						t.Errorf("received nil challenge request")
+					}
+				case 1: // Received Bootstrap Response or Report Status Response.
+					switch resType := response.GetType().(type) {
+					case *bpb.BootstrapStreamResponseV1_BootstrapResponse:
+						if response.GetBootstrapResponse() == nil {
+							t.Errorf("received nil bootstrap data")
+						}
+						if ov := response.GetBootstrapResponse().GetOwnershipVoucher(); !bytes.Equal(ov, testOV) {
+							t.Errorf("unexpected ownership voucher: got %v, want %v", ov, testOV)
+						}
+						if oc := response.GetBootstrapResponse().GetOwnershipCertificate(); !bytes.Equal(oc, testOC) {
+							t.Errorf("unexpected ownership certificate: got %v, want %v", oc, testOC)
+						}
+						if sig := response.GetBootstrapResponse().GetResponseSignature(); sig != testSig {
+							t.Errorf("unexpected response signature: got %v, want %v", sig, testSig)
+						}
+						recipient, err := hpke.NewRecipient(response.GetBootstrapResponse().GetEncapsulatedKey(), hpkeKey, hpke.HKDFSHA256(), hpke.AES256GCM(), nil)
+						if err != nil {
+							t.Fatalf("Failed to create HPKE recipient: %v", err)
+						}
+						plainText, err := recipient.Open(nil, response.GetBootstrapResponse().GetEncryptedSerializedBootstrapData())
+						if err != nil {
+							t.Fatalf("Failed to decrypt bootstrap data: %v", err)
+						}
+						gotBootstrapDataSigned := &bpb.BootstrapDataSigned{}
+						err = proto.Unmarshal(plainText, gotBootstrapDataSigned)
+						if err != nil {
+							t.Fatalf("Failed to unmarshal decrypted bootstrap data: %v", err)
+						}
+						if diff := cmp.Diff(gotBootstrapDataSigned, bootstrapData, protocmp.Transform()); diff != "" {
+							t.Errorf("unexpected BootstrapDataSigned, diff = %v", diff)
+						}
+					case *bpb.BootstrapStreamResponseV1_ReportStatusResponse:
+						if response.GetReportStatusResponse() == nil {
+							t.Errorf("received nil report status response")
+						}
+					default:
+						t.Errorf("received unexpected response type %T", resType)
 					}
 				}
 			}


### PR DESCRIPTION
I need to update go version to 1.26.1 because earlier versions do not have HPKE library.