### PR TITLE
Fix a bug for Streaming Bootz v0.6 where an attacker can bypass challenge.

### DIFF
--- a/server/service/service.go
+++ b/server/service/service.go
@@ -383,6 +383,9 @@ func (s *Service) BootstrapStream(stream bpb.Bootstrap_BootstrapStreamServer) er
 			log.Infof("=============================================================================")
 			log.Infof("====================== Stream status report received ========================")
 			log.Infof("=============================================================================")
+			if session.currentState != stateInitial && session.currentState != stateAttested {
+				return status.Errorf(codes.FailedPrecondition, "unexpected report status request")
+			}
 			log.Infof("Received ReportStatusRequest from %s: %+v", session.chassis.ActiveSerial, req.ReportStatusRequest)
 			session.status = req.ReportStatusRequest
 


### PR DESCRIPTION
Steps to reproduce the bug:

1. The attacker impersonates a device and  sends a ReportStatusRequest in a new stream.
2. The Bootz server sends a ChallengeRequest since this is a new stream.
3. The attacker ignores the received ChallengeRequest and sends the same ReportStatusRequest message again.
4. The Bootz server accepts this ReportStatusRequest message unconditionally. Particularly since now it is not the first message in a new stream, no challenge will be sent out and Bootz server directly updates the status to the bootstrap controller and replies with an acknowledgement to the attacker.