### PR TITLE
Yyamout/public bootz server updates

### DIFF
--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -36,6 +36,7 @@ import (
 	bpb "github.com/openconfig/bootz/proto/bootz"
 	epb "github.com/openconfig/bootz/server/entitymanager/proto/entity"
 	apb "github.com/openconfig/gnsi/authz"
+	ppb "github.com/openconfig/gnsi/pathz"
 )
 
 const defaultRealm = "prod"
@@ -74,6 +75,14 @@ func (m *InMemoryEntityManager) ResolveChassis(ctx context.Context, lookup *serv
 	if err != nil {
 		return nil, err
 	}
+	credzConf, err := m.populateCredentialsConfig(chassis)
+	if err != nil {
+		return nil, err
+	}
+	pathzConf, err := m.populatePathzConfig(chassis)
+	if err != nil {
+		return nil, err
+	}
 	authzConf, err := m.populateAuthzConfig(chassis)
 	if err != nil {
 		return nil, err
@@ -88,6 +97,8 @@ func (m *InMemoryEntityManager) ResolveChassis(ctx context.Context, lookup *serv
 		Serial:                 chassis.GetSerialNumber(),
 		ControlCards:           cards,
 		BootConfig:             bootCfg,
+		Credentials:            credzConf,
+		Pathz:                  pathzConf,
 		Authz:                  authzConf,
 		CertzProfiles:          chassis.GetConfig().GetGnsiConfig().GetCertzProfiles(),
 		BootloaderPasswordHash: chassis.GetBootloaderPasswordHash(),
@@ -161,6 +172,48 @@ func (m *InMemoryEntityManager) populateAuthzConfig(ch *epb.Chassis) (*apb.Uploa
 	return gnsiAuthzReq, nil
 }
 
+func (m *InMemoryEntityManager) populatePathzConfig(ch *epb.Chassis) (*ppb.UploadRequest, error) {
+	gnsiConf := ch.GetConfig().GetGnsiConfig()
+	gnsiPathzReq := gnsiConf.GetPathzUpload()
+	gnsiPathzReqFile := gnsiConf.GetPathzUploadFile()
+	if gnsiPathzReq.GetVersion() != "" && gnsiPathzReq.GetPolicy() != nil {
+		return gnsiPathzReq, nil
+	}
+	if gnsiPathzReqFile == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(gnsiPathzReqFile)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Error opening file %s: %v", gnsiPathzReqFile, err)
+	}
+	gnsiPathzReq = &ppb.UploadRequest{}
+	if err := prototext.Unmarshal(data, gnsiPathzReq); err != nil {
+		return nil, status.Errorf(codes.Internal, "File %s config is not a valid pathz Upload Request: %v", gnsiPathzReqFile, err)
+	}
+	return gnsiPathzReq, nil
+}
+
+func (m *InMemoryEntityManager) populateCredentialsConfig(ch *epb.Chassis) (*bpb.Credentials, error) {
+	gnsiConf := ch.GetConfig().GetGnsiConfig()
+	gnsiCredzReq := gnsiConf.GetCredentials()
+	gnsiCredzReqFile := gnsiConf.GetCredentialsFile()
+	if len(gnsiCredzReq.GetCredentials()) > 0 || len(gnsiCredzReq.GetUsers()) > 0 || len(gnsiCredzReq.GetPasswords()) > 0 {
+		return gnsiCredzReq, nil
+	}
+	if gnsiCredzReqFile == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(gnsiCredzReqFile)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Error opening file %s: %v", gnsiCredzReqFile, err)
+	}
+	gnsiCredzReq = &bpb.Credentials{}
+	if err := prototext.Unmarshal(data, gnsiCredzReq); err != nil {
+		return nil, status.Errorf(codes.Internal, "File %s config is not valid Bootz credentials: %v", gnsiCredzReqFile, err)
+	}
+	return gnsiCredzReq, nil
+}
+
 func populateBootConfig(conf *epb.BootConfig) (*bpb.BootConfig, error) {
 	bootConfig := &bpb.BootConfig{}
 	if conf.GetOcConfigFile() != "" {
@@ -187,16 +240,15 @@ func populateBootConfig(conf *epb.BootConfig) (*bpb.BootConfig, error) {
 
 // GetBootstrapData fetches and returns the bootstrap data response from the server.
 func (m *InMemoryEntityManager) GetBootstrapData(ctx context.Context, chassis *service.Chassis, serial string) (*bpb.BootstrapDataResponse, error) {
-	// TODO: Populate gnsi config
 	return &bpb.BootstrapDataResponse{
 		SerialNum:        serial,
 		IntendedImage:    chassis.SoftwareImage,
 		BootPasswordHash: chassis.BootloaderPasswordHash,
 		ServerTrustCert:  base64.StdEncoding.EncodeToString(m.secArtifacts.TrustAnchor.Raw),
 		BootConfig:       chassis.BootConfig,
-		Credentials:      &bpb.Credentials{},
-		// TODO: Populate pathz, authz and certificates.
-		Authz:         chassis.Authz,
+		Credentials:      chassis.Credentials,
+		Pathz:            chassis.Pathz,
+		Authz:            chassis.Authz,
 		CertzProfiles: chassis.CertzProfiles,
 	}, nil
 }

--- a/server/entitymanager/entitymanager.go
+++ b/server/entitymanager/entitymanager.go
@@ -89,6 +89,7 @@ func (m *InMemoryEntityManager) ResolveChassis(ctx context.Context, lookup *serv
 		ControlCards:           cards,
 		BootConfig:             bootCfg,
 		Authz:                  authzConf,
+		CertzProfiles:          chassis.GetConfig().GetGnsiConfig().GetCertzProfiles(),
 		BootloaderPasswordHash: chassis.GetBootloaderPasswordHash(),
 	}, nil
 }
@@ -195,7 +196,8 @@ func (m *InMemoryEntityManager) GetBootstrapData(ctx context.Context, chassis *s
 		BootConfig:       chassis.BootConfig,
 		Credentials:      &bpb.Credentials{},
 		// TODO: Populate pathz, authz and certificates.
-		Authz: chassis.Authz,
+		Authz:         chassis.Authz,
+		CertzProfiles: chassis.CertzProfiles,
 	}, nil
 }
 

--- a/server/entitymanager/entitymanager_test.go
+++ b/server/entitymanager/entitymanager_test.go
@@ -34,6 +34,9 @@ import (
 	bpb "github.com/openconfig/bootz/proto/bootz"
 	epb "github.com/openconfig/bootz/server/entitymanager/proto/entity"
 	apb "github.com/openconfig/gnsi/authz"
+	cpb "github.com/openconfig/gnsi/certz"
+	kpb "github.com/openconfig/gnsi/credentialz"
+	ppb "github.com/openconfig/gnsi/pathz"
 )
 
 // MustMarshalBootstrapDataSigned is a helper function that marshals a BootstrapDataSigned message.
@@ -480,10 +483,29 @@ func TestGetBootstrapData(t *testing.T) {
 				VendorConfig: []byte(""),
 				OcConfig:     []byte(""),
 			},
+			Credentials: &bpb.Credentials{
+				Credentials: []*kpb.AuthorizedKeysRequest{{
+					Credentials: []*kpb.AccountCredentials{{
+						Account: "gnetch",
+						AuthorizedKeys: []*kpb.AccountCredentials_AuthorizedKey{{
+							AuthorizedKey: []byte("AAAA-test-key"),
+						}},
+					}},
+				}},
+			},
+			Pathz: &ppb.UploadRequest{
+				Version: "pathz-v1",
+			},
 			Authz: &apb.UploadRequest{
 				Version:   "v0.1694813669807611349",
 				CreatedOn: 1694813669807,
 				Policy:    "{\"name\":\"default\",\"request\":{\"paths\":[\"*\"]},\"source\":{\"principals\":[\"cafyauto\"]}}",
+			},
+			CertzProfiles: &bpb.CertzProfiles{
+				Profiles: []*bpb.CertzProfile{{
+					SslProfileId: "tls",
+					Certz:        &cpb.UploadRequest{},
+				}},
 			},
 		},
 		want: &bpb.BootstrapDataResponse{
@@ -501,11 +523,29 @@ func TestGetBootstrapData(t *testing.T) {
 				VendorConfig: []byte(""),
 				OcConfig:     []byte(""),
 			},
-			Credentials: &bpb.Credentials{},
+			Credentials: &bpb.Credentials{
+				Credentials: []*kpb.AuthorizedKeysRequest{{
+					Credentials: []*kpb.AccountCredentials{{
+						Account: "gnetch",
+						AuthorizedKeys: []*kpb.AccountCredentials_AuthorizedKey{{
+							AuthorizedKey: []byte("AAAA-test-key"),
+						}},
+					}},
+				}},
+			},
+			Pathz: &ppb.UploadRequest{
+				Version: "pathz-v1",
+			},
 			Authz: &apb.UploadRequest{
 				Version:   "v0.1694813669807611349",
 				CreatedOn: 1694813669807,
 				Policy:    "{\"name\":\"default\",\"request\":{\"paths\":[\"*\"]},\"source\":{\"principals\":[\"cafyauto\"]}}",
+			},
+			CertzProfiles: &bpb.CertzProfiles{
+				Profiles: []*bpb.CertzProfile{{
+					SslProfileId: "tls",
+					Certz:        &cpb.UploadRequest{},
+				}},
 			},
 		},
 		wantErr: false,

--- a/server/entitymanager/proto/entity.proto
+++ b/server/entitymanager/proto/entity.proto
@@ -103,6 +103,9 @@ message GNSIConfig {
   // gnsi credential config
   bootz.Credentials credentials = 8;
 
+  // Certz profiles to create, including the target SSL profile ID.
+  bootz.CertzProfiles certz_profiles = 9;
+
 }
 
 message  DHCPConfig {
@@ -161,6 +164,5 @@ message Chassis {
   // dhcp config for fixed chassis
   DHCPConfig dhcp_config =12 ;
 }
-
 
 

--- a/server/entitymanager/proto/entity/entity.pb.go
+++ b/server/entitymanager/proto/entity/entity.pb.go
@@ -7,6 +7,9 @@
 package entity
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	bootz "github.com/openconfig/bootz/proto/bootz"
 	authz "github.com/openconfig/gnsi/authz"
 	certz "github.com/openconfig/gnsi/certz"
@@ -14,8 +17,6 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (
@@ -283,6 +284,7 @@ type GNSIConfig struct {
 	CertzUploadFile string                 `protobuf:"bytes,6,opt,name=certz_upload_file,json=certzUploadFile,proto3" json:"certz_upload_file,omitempty"`
 	CredentialsFile string                 `protobuf:"bytes,7,opt,name=credentials_file,json=credentialsFile,proto3" json:"credentials_file,omitempty"`
 	Credentials     *bootz.Credentials     `protobuf:"bytes,8,opt,name=credentials,proto3" json:"credentials,omitempty"`
+	CertzProfiles   *bootz.CertzProfiles   `protobuf:"bytes,9,opt,name=certz_profiles,json=certzProfiles,proto3" json:"certz_profiles,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -369,6 +371,13 @@ func (x *GNSIConfig) GetCredentialsFile() string {
 func (x *GNSIConfig) GetCredentials() *bootz.Credentials {
 	if x != nil {
 		return x.Credentials
+	}
+	return nil
+}
+
+func (x *GNSIConfig) GetCertzProfiles() *bootz.CertzProfiles {
+	if x != nil {
+		return x.CertzProfiles
 	}
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,9 @@ import (
 	"github.com/openconfig/bootz/server/entitymanager"
 	"github.com/openconfig/bootz/server/service"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 
 	bpb "github.com/openconfig/bootz/proto/bootz"
 )
@@ -88,9 +90,37 @@ type InterceptorOpts struct {
 
 func (*InterceptorOpts) isbootzServerOpts() {}
 
+// DisableBootstrapStream disables the deprecated BootstrapStream RPC while
+// keeping unary RPCs available.
+type DisableBootstrapStream struct{}
+
+func (*DisableBootstrapStream) isbootzServerOpts() {}
+
+type bootstrapServer struct {
+	bpb.UnimplementedBootstrapServer
+	service                *service.Service
+	disableBootstrapStream bool
+}
+
+func (s *bootstrapServer) GetBootstrapData(ctx context.Context, req *bpb.GetBootstrapDataRequest) (*bpb.GetBootstrapDataResponse, error) {
+	return s.service.GetBootstrapData(ctx, req)
+}
+
+func (s *bootstrapServer) ReportStatus(ctx context.Context, req *bpb.ReportStatusRequest) (*bpb.EmptyResponse, error) {
+	return s.service.ReportStatus(ctx, req)
+}
+
+func (s *bootstrapServer) BootstrapStream(stream bpb.Bootstrap_BootstrapStreamServer) error {
+	if s.disableBootstrapStream {
+		return status.Error(codes.Unimplemented, "BootstrapStream disabled")
+	}
+	return s.service.BootstrapStream(stream)
+}
+
 // NewServer start a new Bootz gRPC , dhcp, and image server based on specified flags.
 func NewServer(bootzAddr string, em *entitymanager.InMemoryEntityManager, sa *service.SecurityArtifacts, opts ...bootzServerOpts) (*Server, error) {
 	var interceptor grpc.ServerOption
+	disableBootstrapStream := false
 	server := &Server{}
 	for _, opt := range opts {
 		switch opt := opt.(type) {
@@ -102,6 +132,8 @@ func NewServer(bootzAddr string, em *entitymanager.InMemoryEntityManager, sa *se
 			server.httpSrv = StartImageServer(opt)
 		case *InterceptorOpts:
 			interceptor = grpc.UnaryInterceptor(opt.BootzInterceptor)
+		case *DisableBootstrapStream:
+			disableBootstrapStream = true
 		default:
 			continue
 		}
@@ -124,7 +156,10 @@ func NewServer(bootzAddr string, em *entitymanager.InMemoryEntityManager, sa *se
 		s = grpc.NewServer(grpc.Creds(credentials.NewTLS(tls)))
 	}
 
-	bpb.RegisterBootstrapServer(s, c)
+	bpb.RegisterBootstrapServer(s, &bootstrapServer{
+		service:                c,
+		disableBootstrapStream: disableBootstrapStream,
+	})
 
 	lis, err := net.Listen("tcp", bootzAddr)
 	if err != nil {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -98,6 +98,7 @@ type Chassis struct {
 	// cases where this data should be hardcoded e.g. for testing.
 	BootConfig             *bpb.BootConfig
 	Authz                  *apb.UploadRequest
+	CertzProfiles          *bpb.CertzProfiles
 	BootloaderPasswordHash string
 }
 

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -32,6 +32,7 @@ import (
 	log "github.com/golang/glog"
 	bpb "github.com/openconfig/bootz/proto/bootz"
 	apb "github.com/openconfig/gnsi/authz"
+	ppb "github.com/openconfig/gnsi/pathz"
 )
 
 // OVList is a mapping of control card serial number to ownership voucher.
@@ -97,6 +98,8 @@ type Chassis struct {
 	// The below fields are normally unset and are primarily used for
 	// cases where this data should be hardcoded e.g. for testing.
 	BootConfig             *bpb.BootConfig
+	Credentials            *bpb.Credentials
+	Pathz                  *ppb.UploadRequest
 	Authz                  *apb.UploadRequest
 	CertzProfiles          *bpb.CertzProfiles
 	BootloaderPasswordHash string

--- a/testdata/artifacts.go
+++ b/testdata/artifacts.go
@@ -28,6 +28,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"math/big"
+	"net"
 	"time"
 
 	"github.com/openconfig/bootz/server/service"
@@ -58,11 +59,20 @@ type Inner struct {
 	DomainCertRevocationChecks bool     `json:"domain-cert-revocation-checks" xml:"domain-cert-revocation-checks"`
 }
 
+func certificateSANs(serverName string) ([]string, []net.IP) {
+	if ip := net.ParseIP(serverName); ip != nil {
+		return nil, []net.IP{ip}
+	}
+	return []string{serverName}, nil
+}
+
 // NewCertificateAuthority creates a new self-signed CA for the chosen organization.
 func NewCertificateAuthority(commonName, org, serverName string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	dnsNames, ipAddresses := certificateSANs(serverName)
 	// Create the certificate authority.
 	ca := &x509.Certificate{
-		DNSNames:     []string{serverName},
+		DNSNames:     dnsNames,
+		IPAddresses:  ipAddresses,
 		SerialNumber: big.NewInt(int64(time.Now().Year())),
 		Subject: pkix.Name{
 			CommonName:   commonName,
@@ -100,9 +110,11 @@ func NewCertificateAuthority(commonName, org, serverName string) (*x509.Certific
 
 // NewSignedCertificate creates a new cert/private keypair signed by the provided Certificate Authority.
 func NewSignedCertificate(commonName, org, serverName string, ca *x509.Certificate, caPrivateKey crypto.PrivateKey) (*x509.Certificate, *rsa.PrivateKey, error) {
+	dnsNames, ipAddresses := certificateSANs(serverName)
 	// Create the certificate template. Geographic information is the same as the Certificate Authority by default.
 	template := &x509.Certificate{
-		DNSNames:     []string{serverName},
+		DNSNames:     dnsNames,
+		IPAddresses:  ipAddresses,
 		SerialNumber: big.NewInt(int64(time.Now().Year())),
 		Subject: pkix.Name{
 			CommonName:   commonName,


### PR DESCRIPTION
This PR adds the public Bootz server support needed for the first featureprofiles Bootz FNT case.

**feature profile PR**: https://github.com/openconfig/featureprofiles/pull/5016

Included in here:
- IP SAN support for generated test certificates
- support for disabling `BootstrapStream` so tests can use the unary flow
- CertZ profile plumbing in bootstrap data
- PathZ and CredZ propagation in bootstrap data

This is intended to support the initial public featureprofiles Bootz test flow and close some gaps between the current public server behaviour and the test environment.

A couple of notes:
- the first public featureprofiles test is still the minimum-config flow
- PathZ and CredZ are not exercised by that first test yet, even though this branch includes the server-side plumbing for them
- the current featureprofiles side still works around the server’s AuthZ inventory requirement for that minimum-config case

So this PR gets the public server into the right shape for the first test. More tests will follow up validation, and we will have medications here as needed!

Adding for reference: https://github.com/openconfig/featureprofiles/pull/5016
