### PR TITLE
Parallelize control card bootstrap data fetching

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,6 @@ go_sdk.download(version = "1.26.4")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
-use_repo(go_deps, "com_github_coredhcp_coredhcp", "com_github_golang_glog", "com_github_google_go_cmp", "com_github_google_go_tpm", "com_github_insomniacslk_dhcp", "com_github_openconfig_monax", "org_golang_google_grpc", "org_golang_google_grpc_cmd_protoc_gen_go_grpc", "org_golang_google_protobuf", "org_mozilla_go_pkcs7")
+use_repo(go_deps, "com_github_coredhcp_coredhcp", "com_github_golang_glog", "com_github_google_go_cmp", "com_github_google_go_tpm", "com_github_insomniacslk_dhcp", "com_github_openconfig_monax", "org_golang_google_grpc", "org_golang_google_grpc_cmd_protoc_gen_go_grpc", "org_golang_google_protobuf", "org_mozilla_go_pkcs7", "org_golang_x_sync")
 
 go_deps_dev = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps", dev_dependency = True)

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/openconfig/gnsi v1.9.1
 	github.com/openconfig/monax v0.0.0-20260626002019-e784596c3dca
 	go.mozilla.org/pkcs7 v0.9.0
+	golang.org/x/sync v0.21.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af

--- a/server/service/BUILD.bazel
+++ b/server/service/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "@org_golang_google_grpc//peer",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -41,6 +41,7 @@ import (
 	ownercertificate "github.com/openconfig/bootz/common/owner_certificate"
 	"github.com/openconfig/bootz/common/signature"
 	"github.com/openconfig/bootz/common/types"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
@@ -174,21 +175,31 @@ func (s *Service) GetBootstrapData(ctx context.Context, req *bpb.GetBootstrapDat
 	log.Infof("=============================================================================")
 	log.Infof("==================== Fetching data for each control card ====================")
 	log.Infof("=============================================================================")
-	var responses []*bpb.BootstrapDataResponse
 	trustAnchorCert, _ := s.am.BootzServerTrustAnchorKeyPair()
 	if trustAnchorCert == nil {
 		return nil, status.Errorf(codes.Internal, "failed to retrieve server trust cert")
 	}
 	trustAnchor := base64.StdEncoding.EncodeToString(trustAnchorCert.Raw)
-	// Iterate over the control cards and fetch data for each card.
-	for _, v := range serials {
-		bootdata, err := s.cm.GenerateBootstrapData(ctx, chassis, v)
-		if err != nil {
-			log.Infof("Error occurred while retrieving bootstrap data for serial number %v", v)
-			return nil, err
-		}
-		bootdata.ServerTrustCert = trustAnchor
-		responses = append(responses, bootdata)
+	responses := make([]*bpb.BootstrapDataResponse, len(serials))
+	group, childCtx := errgroup.WithContext(ctx)
+
+	// Iterate over the control cards in parallel.
+	for i, serial := range serials {
+		group.Go(func() error {
+			log.Infof("Fetching bootstrap data for serial number %s", serial)
+			bootdata, err := s.cm.GenerateBootstrapData(childCtx, chassis, serial)
+			if err != nil {
+				log.Infof("Error occurred while retrieving bootstrap data for serial number %v: %v", serial, err)
+				return err
+			}
+			bootdata.ServerTrustCert = trustAnchor
+			responses[i] = bootdata
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 
 	log.Infof("Successfully fetched data for each control card")
@@ -386,21 +397,31 @@ func (s *Service) BootstrapStream(stream bpb.Bootstrap_BootstrapStreamServer) er
 			}
 
 			// If verification is successful, fetch and send the bootstrap data.
-			var responses []*bpb.BootstrapDataResponse
 			trustAnchorCert, _ := s.am.BootzServerTrustAnchorKeyPair()
 			if trustAnchorCert == nil {
 				return status.Errorf(codes.Internal, "failed to retrieve server trust cert")
 			}
 			trustAnchor := base64.StdEncoding.EncodeToString(trustAnchorCert.Raw)
-			for _, v := range session.chassis.Serials {
-				log.Infof("Fetching bootstrap data for serial number %s", v)
-				bootdata, err := s.cm.GenerateBootstrapData(ctx, session.chassis, v)
-				if err != nil {
-					log.Infof("Error occurred while retrieving bootstrap data for serial number %v", v)
-					return err
-				}
-				bootdata.ServerTrustCert = trustAnchor
-				responses = append(responses, bootdata)
+
+			responses := make([]*bpb.BootstrapDataResponse, len(session.chassis.Serials))
+			g, childCtx := errgroup.WithContext(ctx)
+
+			for i, serial := range session.chassis.Serials {
+				g.Go(func() error {
+					log.Infof("Fetching bootstrap data for serial number %s", serial)
+					bootdata, err := s.cm.GenerateBootstrapData(childCtx, session.chassis, serial)
+					if err != nil {
+						log.Infof("Error occurred while retrieving bootstrap data for serial number %v: %v", serial, err)
+						return err
+					}
+					bootdata.ServerTrustCert = trustAnchor
+					responses[i] = bootdata
+					return nil
+				})
+			}
+
+			if err := g.Wait(); err != nil {
+				return err
 			}
 			serializedSignedData, err := proto.Marshal(&bpb.BootstrapDataSigned{
 				Responses: responses,
@@ -615,21 +636,31 @@ func (s *Service) BootstrapStreamV1(stream bpb.Bootstrap_BootstrapStreamV1Server
 				}
 			} else {
 				// Otherwise fetch the bootstrap data.
-				var bootstrapData []*bpb.BootstrapDataResponse
 				trustAnchorCert, _ := s.am.BootzServerTrustAnchorKeyPair()
 				if trustAnchorCert == nil {
 					return status.Errorf(codes.Internal, "failed to retrieve server trust cert")
 				}
 				trustAnchor := base64.StdEncoding.EncodeToString(trustAnchorCert.Raw)
-				for _, v := range session.chassis.Serials {
-					log.Infof("Fetching bootstrap data for serial number: %s", v)
-					data, err := s.cm.GenerateBootstrapData(ctx, session.chassis, v)
-					if err != nil {
-						log.Infof("Error occurred while retrieving bootstrap data for serial number %v", v)
-						return err
-					}
-					data.ServerTrustCert = trustAnchor
-					bootstrapData = append(bootstrapData, data)
+
+				bootstrapData := make([]*bpb.BootstrapDataResponse, len(session.chassis.Serials))
+				g, childCtx := errgroup.WithContext(ctx)
+
+				for i, serial := range session.chassis.Serials {
+					g.Go(func() error {
+						log.Infof("Fetching bootstrap data for serial number: %s", serial)
+						data, err := s.cm.GenerateBootstrapData(childCtx, session.chassis, serial)
+						if err != nil {
+							log.Infof("Error occurred while retrieving bootstrap data for serial number %v: %v", serial, err)
+							return err
+						}
+						data.ServerTrustCert = trustAnchor
+						bootstrapData[i] = data
+						return nil
+					})
+				}
+
+				if err := g.Wait(); err != nil {
+					return err
 				}
 				serializedBootstrapData, err := proto.Marshal(&bpb.BootstrapDataSigned{
 					Responses: bootstrapData,


### PR DESCRIPTION
Uses errgroup to process supervisor control cards concurrently in GetBootstrapData, BootstrapStream, and BootstrapStreamV1. .