### PR TITLE
Enable skipping IDevId serial validation.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -380,6 +380,10 @@ func main() {
 	if bootzAddress == "" {
 		log.Exit("Bootz server address not found in config file.")
 	}
+	serverPort := config.GetServerPort()
+	if serverPort == "" {
+		log.Exit("Bootz server port not found in config file.")
+	}
 	log.Infof("=============================================================================")
 	log.Infof("=========================== BootZ Client Emulator ===========================")
 	log.Infof("=============================================================================")
@@ -441,8 +445,9 @@ func main() {
 	if !*streaming {
 		tlsConfig.Certificates = []tls.Certificate{*idevid}
 	}
-	log.Infof("Connecting to bootz server at address %q", bootzAddress)
-	conn, err := grpc.Dial(bootzAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	serverAddress := "[" + bootzAddress + "]:" + serverPort
+	log.Infof("Connecting to bootz server at address %q", serverAddress)
+	conn, err := grpc.NewClient(serverAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {
 		log.Exitf("Client unable to connect to Bootstrap Server: %v", err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -445,7 +446,7 @@ func main() {
 	if !*streaming {
 		tlsConfig.Certificates = []tls.Certificate{*idevid}
 	}
-serverAddress := net.JoinHostPort(bootzAddress, serverPort)
+	serverAddress := net.JoinHostPort(bootzAddress, serverPort)
 	log.Infof("Connecting to bootz server at address %q", serverAddress)
 	conn, err := grpc.NewClient(serverAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -445,7 +445,7 @@ func main() {
 	if !*streaming {
 		tlsConfig.Certificates = []tls.Certificate{*idevid}
 	}
-	serverAddress := "[" + bootzAddress + "]:" + serverPort
+serverAddress := net.JoinHostPort(bootzAddress, serverPort)
 	log.Infof("Connecting to bootz server at address %q", serverAddress)
 	conn, err := grpc.NewClient(serverAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	if err != nil {

--- a/server/chassismanager/BUILD.bazel
+++ b/server/chassismanager/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "chassismanager",
@@ -24,5 +24,20 @@ go_library(
         "//proto:bootz",
         "//server/proto:config",
         "@com_github_golang_glog//:glog",
+    ],
+)
+
+go_test(
+    name = "chassismanager_test",
+    srcs = ["chassismanager_test.go"],
+    embed = [":chassismanager"],
+    deps = [
+        "//common/types",
+        "//proto:bootz",
+        "//server/proto:config",
+        "@com_github_google_go_cmp//cmp",
+        "@openconfig_gnsi//authz",
+        "@openconfig_gnsi//pathz",
+        "@org_golang_google_protobuf//testing/protocmp",
     ],
 )

--- a/server/chassismanager/chassismanager.go
+++ b/server/chassismanager/chassismanager.go
@@ -46,6 +46,7 @@ func (m *InMemoryChassisManager) ResolveChassis(ctx context.Context, chassis *ty
 	chassis.BootMode = found.GetBootMode()
 	chassis.StreamingSupported = found.GetStreamingSupported()
 	chassis.Manufacturer = found.GetManufacturer()
+	chassis.SkipIDevIDSerialValidation = found.GetSkipIdevidSerialValidation()
 	return nil
 }
 

--- a/server/chassismanager/chassismanager_test.go
+++ b/server/chassismanager/chassismanager_test.go
@@ -128,52 +128,33 @@ func TestInMemoryChassisManager(t *testing.T) {
 	})
 
 	// 4. Test GenerateBootstrapData
-
-	serials := []string{serial1, serial2}
-	responses, err := manager.GenerateBootstrapData(ctx, nil, serials)
-	for i, serial := range serials {
-		t.Run(serial, func(t *testing.T) {
-			resp := responses[i]
-			want := &bpb.BootstrapDataResponse{
-				SerialNum:        serial,
-				IntendedImage:    intendedImage,
-				BootPasswordHash: bootPasswordHash,
-				BootConfig:       bootConfig,
-				Pathz:            pathzReq,
-				Authz:            authzReq,
-				CertzProfiles:    certzProfiles,
-				Credentials:      credentials,
-			}
-			if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
-				t.Errorf("GenerateBootstrapData response mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
 	t.Run("GenerateBootstrapData Success", func(t *testing.T) {
 
+		serials := []string{serial1, serial2}
+		responses, err := manager.GenerateBootstrapData(ctx, nil, serials)
 		if err != nil {
 			t.Fatalf("GenerateBootstrapData failed: %v", err)
 		}
-
 		if len(responses) != len(serials) {
 			t.Fatalf("GenerateBootstrapData got %d responses, want %d", len(responses), len(serials))
 		}
-
 		for i, serial := range serials {
-			resp := responses[i]
-			want := &bpb.BootstrapDataResponse{
-				SerialNum:        serial,
-				IntendedImage:    intendedImage,
-				BootPasswordHash: bootPasswordHash,
-				BootConfig:       bootConfig,
-				Pathz:            pathzReq,
-				Authz:            authzReq,
-				CertzProfiles:    certzProfiles,
-				Credentials:      credentials,
-			}
-			if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
-				t.Errorf("GenerateBootstrapData response mismatch (-want +got):\n%s", diff)
-			}
+			t.Run(serial, func(t *testing.T) {
+				resp := responses[i]
+				want := &bpb.BootstrapDataResponse{
+					SerialNum:        serial,
+					IntendedImage:    intendedImage,
+					BootPasswordHash: bootPasswordHash,
+					BootConfig:       bootConfig,
+					Pathz:            pathzReq,
+					Authz:            authzReq,
+					CertzProfiles:    certzProfiles,
+					Credentials:      credentials,
+				}
+				if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+					t.Errorf("GenerateBootstrapData response mismatch (-want +got):\n%s", diff)
+				}
+			})
 		}
 	})
 

--- a/server/chassismanager/chassismanager_test.go
+++ b/server/chassismanager/chassismanager_test.go
@@ -97,20 +97,16 @@ func TestInMemoryChassisManager(t *testing.T) {
 			t.Fatalf("ResolveChassis failed: %v", err)
 		}
 
-		if ch.Hostname != hostname {
-			t.Errorf("ResolveChassis got hostname %q, want %q", ch.Hostname, hostname)
+		want := &types.Chassis{
+			ActiveSerial:               serial1,
+			Hostname:                   hostname,
+			BootMode:                   bootMode,
+			StreamingSupported:         streamingSupported,
+			Manufacturer:               manufacturer,
+			SkipIDevIDSerialValidation: skipIDevID,
 		}
-		if ch.BootMode != bootMode {
-			t.Errorf("ResolveChassis got BootMode %v, want %v", ch.BootMode, bootMode)
-		}
-		if ch.StreamingSupported != streamingSupported {
-			t.Errorf("ResolveChassis got StreamingSupported %v, want %v", ch.StreamingSupported, streamingSupported)
-		}
-		if ch.Manufacturer != manufacturer {
-			t.Errorf("ResolveChassis got Manufacturer %q, want %q", ch.Manufacturer, manufacturer)
-		}
-		if ch.SkipIDevIDSerialValidation != skipIDevID {
-			t.Errorf("ResolveChassis got SkipIDevIDSerialValidation %v, want %v", ch.SkipIDevIDSerialValidation, skipIDevID)
+		if diff := cmp.Diff(want, ch, protocmp.Transform()); diff != "" {
+			t.Errorf("ResolveChassis() mismatch (-want +got):\n%s", diff)
 		}
 	})
 

--- a/server/chassismanager/chassismanager_test.go
+++ b/server/chassismanager/chassismanager_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chassismanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/bootz/common/types"
+	"github.com/openconfig/gnsi/authz"
+	"github.com/openconfig/gnsi/pathz"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	bpb "github.com/openconfig/bootz/proto/bootz"
+	cpb "github.com/openconfig/bootz/server/proto/config"
+)
+
+func TestInMemoryChassisManager(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Setup Test Data
+	serial1 := "serial-123"
+	serial2 := "serial-456"
+	serialNotFound := "serial-999"
+
+	hostname := "test-hostname"
+	bootMode := bpb.BootMode_BOOT_MODE_SECURE
+	streamingSupported := true
+	manufacturer := "test-manufacturer"
+	bootPasswordHash := "test-password-hash"
+	skipIDevID := true
+
+	intendedImage := &bpb.SoftwareImage{
+		Version: "1.2.3",
+		Url:     "http://example.com/image",
+	}
+	bootConfig := &bpb.BootConfig{
+		VendorConfig: []byte("test-vendor-config"),
+	}
+	credentials := &bpb.Credentials{
+		Passwords: nil,
+	}
+	pathzReq := &pathz.UploadRequest{}
+	authzReq := &authz.UploadRequest{}
+	certzProfiles := &bpb.CertzProfiles{}
+
+	config := &cpb.Config{
+		Chassis: []*cpb.Chassis{
+			{
+				Manufacturer:               manufacturer,
+				Hostname:                   hostname,
+				BootMode:                   bootMode,
+				StreamingSupported:         streamingSupported,
+				IntendedImage:              intendedImage,
+				BootPasswordHash:           bootPasswordHash,
+				BootConfig:                 bootConfig,
+				Credentials:                credentials,
+				Pathz:                      pathzReq,
+				Authz:                      authzReq,
+				CertzProfiles:              certzProfiles,
+				SkipIdevidSerialValidation: skipIDevID,
+				ControlCards: []*cpb.ControlCard{
+					{
+						SerialNumber: serial1,
+					},
+					{
+						SerialNumber: serial2,
+					},
+				},
+			},
+		},
+	}
+
+	// 2. Initialize Chassis Manager
+	manager := New(config)
+
+	// 3. Test ResolveChassis
+	t.Run("ResolveChassis Success", func(t *testing.T) {
+		ch := &types.Chassis{
+			ActiveSerial: serial1,
+		}
+		err := manager.ResolveChassis(ctx, ch)
+		if err != nil {
+			t.Fatalf("ResolveChassis failed: %v", err)
+		}
+
+		if ch.Hostname != hostname {
+			t.Errorf("ResolveChassis got hostname %q, want %q", ch.Hostname, hostname)
+		}
+		if ch.BootMode != bootMode {
+			t.Errorf("ResolveChassis got BootMode %v, want %v", ch.BootMode, bootMode)
+		}
+		if ch.StreamingSupported != streamingSupported {
+			t.Errorf("ResolveChassis got StreamingSupported %v, want %v", ch.StreamingSupported, streamingSupported)
+		}
+		if ch.Manufacturer != manufacturer {
+			t.Errorf("ResolveChassis got Manufacturer %q, want %q", ch.Manufacturer, manufacturer)
+		}
+		if ch.SkipIDevIDSerialValidation != skipIDevID {
+			t.Errorf("ResolveChassis got SkipIDevIDSerialValidation %v, want %v", ch.SkipIDevIDSerialValidation, skipIDevID)
+		}
+	})
+
+	t.Run("ResolveChassis Nil Chassis", func(t *testing.T) {
+		err := manager.ResolveChassis(ctx, nil)
+		if err == nil {
+			t.Errorf("ResolveChassis on nil chassis succeeded, want error")
+		}
+	})
+
+	t.Run("ResolveChassis Not Found", func(t *testing.T) {
+		ch := &types.Chassis{
+			ActiveSerial: serialNotFound,
+		}
+		err := manager.ResolveChassis(ctx, ch)
+		if err == nil {
+			t.Errorf("ResolveChassis with unknown serial succeeded, want error")
+		}
+	})
+
+	// 4. Test GenerateBootstrapData
+	t.Run("GenerateBootstrapData Success", func(t *testing.T) {
+		serials := []string{serial1, serial2}
+		responses, err := manager.GenerateBootstrapData(ctx, nil, serials)
+		if err != nil {
+			t.Fatalf("GenerateBootstrapData failed: %v", err)
+		}
+
+		if len(responses) != len(serials) {
+			t.Fatalf("GenerateBootstrapData got %d responses, want %d", len(responses), len(serials))
+		}
+
+		for i, serial := range serials {
+			resp := responses[i]
+			if resp.SerialNum != serial {
+				t.Errorf("GenerateBootstrapData[%d] got serial %q, want %q", i, resp.SerialNum, serial)
+			}
+			if diff := cmp.Diff(resp.IntendedImage, intendedImage, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateBootstrapData[%d] IntendedImage diff (-got +want):\n%s", i, diff)
+			}
+			if resp.BootPasswordHash != bootPasswordHash {
+				t.Errorf("GenerateBootstrapData[%d] got BootPasswordHash %q, want %q", i, resp.BootPasswordHash, bootPasswordHash)
+			}
+			if diff := cmp.Diff(resp.BootConfig, bootConfig, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateBootstrapData[%d] BootConfig diff (-got +want):\n%s", i, diff)
+			}
+			if diff := cmp.Diff(resp.Credentials, credentials, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateBootstrapData[%d] Credentials diff (-got +want):\n%s", i, diff)
+			}
+			if diff := cmp.Diff(resp.Pathz, pathzReq, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateBootstrapData[%d] Pathz diff (-got +want):\n%s", i, diff)
+			}
+			if diff := cmp.Diff(resp.Authz, authzReq, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateBootstrapData[%d] Authz diff (-got +want):\n%s", i, diff)
+			}
+			if diff := cmp.Diff(resp.CertzProfiles, certzProfiles, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateBootstrapData[%d] CertzProfiles diff (-got +want):\n%s", i, diff)
+			}
+		}
+	})
+
+	t.Run("GenerateBootstrapData Not Found", func(t *testing.T) {
+		serials := []string{serial1, serialNotFound}
+		_, err := manager.GenerateBootstrapData(ctx, nil, serials)
+		if err == nil {
+			t.Errorf("GenerateBootstrapData with unknown serial succeeded, want error")
+		}
+	})
+
+	// 5. Test UpdateStatus
+	t.Run("UpdateStatus Success", func(t *testing.T) {
+		req := &bpb.ReportStatusRequest{
+			Status:        bpb.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
+			StatusMessage: "test status message",
+			States: []*bpb.ControlCardState{
+				{
+					SerialNumber: serial1,
+					Status:       bpb.ControlCardState_CONTROL_CARD_STATUS_INITIALIZED,
+				},
+			},
+		}
+		err := manager.UpdateStatus(ctx, req)
+		if err != nil {
+			t.Errorf("UpdateStatus failed: %v", err)
+		}
+	})
+
+	t.Run("UpdateStatus No States", func(t *testing.T) {
+		req := &bpb.ReportStatusRequest{
+			Status:        bpb.ReportStatusRequest_BOOTSTRAP_STATUS_SUCCESS,
+			StatusMessage: "test status message",
+		}
+		err := manager.UpdateStatus(ctx, req)
+		if err == nil {
+			t.Errorf("UpdateStatus with no states succeeded, want error")
+		}
+	})
+}

--- a/server/chassismanager/chassismanager_test.go
+++ b/server/chassismanager/chassismanager_test.go
@@ -128,9 +128,29 @@ func TestInMemoryChassisManager(t *testing.T) {
 	})
 
 	// 4. Test GenerateBootstrapData
+
+	serials := []string{serial1, serial2}
+	responses, err := manager.GenerateBootstrapData(ctx, nil, serials)
+	for i, serial := range serials {
+		t.Run(serial, func(t *testing.T) {
+			resp := responses[i]
+			want := &bpb.BootstrapDataResponse{
+				SerialNum:        serial,
+				IntendedImage:    intendedImage,
+				BootPasswordHash: bootPasswordHash,
+				BootConfig:       bootConfig,
+				Pathz:            pathzReq,
+				Authz:            authzReq,
+				CertzProfiles:    certzProfiles,
+				Credentials:      credentials,
+			}
+			if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateBootstrapData response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 	t.Run("GenerateBootstrapData Success", func(t *testing.T) {
-		serials := []string{serial1, serial2}
-		responses, err := manager.GenerateBootstrapData(ctx, nil, serials)
+
 		if err != nil {
 			t.Fatalf("GenerateBootstrapData failed: %v", err)
 		}
@@ -141,29 +161,18 @@ func TestInMemoryChassisManager(t *testing.T) {
 
 		for i, serial := range serials {
 			resp := responses[i]
-			if resp.SerialNum != serial {
-				t.Errorf("GenerateBootstrapData[%d] got serial %q, want %q", i, resp.SerialNum, serial)
+			want := &bpb.BootstrapDataResponse{
+				SerialNum:        serial,
+				IntendedImage:    intendedImage,
+				BootPasswordHash: bootPasswordHash,
+				BootConfig:       bootConfig,
+				Pathz:            pathzReq,
+				Authz:            authzReq,
+				CertzProfiles:    certzProfiles,
+				Credentials:      credentials,
 			}
-			if diff := cmp.Diff(resp.IntendedImage, intendedImage, protocmp.Transform()); diff != "" {
-				t.Errorf("GenerateBootstrapData[%d] IntendedImage diff (-got +want):\n%s", i, diff)
-			}
-			if resp.BootPasswordHash != bootPasswordHash {
-				t.Errorf("GenerateBootstrapData[%d] got BootPasswordHash %q, want %q", i, resp.BootPasswordHash, bootPasswordHash)
-			}
-			if diff := cmp.Diff(resp.BootConfig, bootConfig, protocmp.Transform()); diff != "" {
-				t.Errorf("GenerateBootstrapData[%d] BootConfig diff (-got +want):\n%s", i, diff)
-			}
-			if diff := cmp.Diff(resp.Credentials, credentials, protocmp.Transform()); diff != "" {
-				t.Errorf("GenerateBootstrapData[%d] Credentials diff (-got +want):\n%s", i, diff)
-			}
-			if diff := cmp.Diff(resp.Pathz, pathzReq, protocmp.Transform()); diff != "" {
-				t.Errorf("GenerateBootstrapData[%d] Pathz diff (-got +want):\n%s", i, diff)
-			}
-			if diff := cmp.Diff(resp.Authz, authzReq, protocmp.Transform()); diff != "" {
-				t.Errorf("GenerateBootstrapData[%d] Authz diff (-got +want):\n%s", i, diff)
-			}
-			if diff := cmp.Diff(resp.CertzProfiles, certzProfiles, protocmp.Transform()); diff != "" {
-				t.Errorf("GenerateBootstrapData[%d] CertzProfiles diff (-got +want):\n%s", i, diff)
+			if diff := cmp.Diff(want, resp, protocmp.Transform()); diff != "" {
+				t.Errorf("GenerateBootstrapData response mismatch (-want +got):\n%s", diff)
 			}
 		}
 	})

--- a/server/proto/config.proto
+++ b/server/proto/config.proto
@@ -73,6 +73,8 @@ message Chassis {
   gnsi.authz.v1.UploadRequest authz = 11;
   // Certz profiles.
   bootz.CertzProfiles certz_profiles = 12;
+  // Skip IDevID serial validation (default is false).
+  bool skip_idevid_serial_validation = 13;
 }
 
 message ControlCard {

--- a/server/proto/config/config.pb.go
+++ b/server/proto/config/config.pb.go
@@ -162,21 +162,22 @@ func (x *CertKeyPair) GetKey() string {
 }
 
 type Chassis struct {
-	state              protoimpl.MessageState `protogen:"open.v1"`
-	Manufacturer       string                 `protobuf:"bytes,1,opt,name=manufacturer,proto3" json:"manufacturer,omitempty"`
-	ControlCards       []*ControlCard         `protobuf:"bytes,2,rep,name=control_cards,json=controlCards,proto3" json:"control_cards,omitempty"`
-	Hostname           string                 `protobuf:"bytes,3,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	BootMode           bootz.BootMode         `protobuf:"varint,4,opt,name=boot_mode,json=bootMode,proto3,enum=bootz.BootMode" json:"boot_mode,omitempty"`
-	StreamingSupported bool                   `protobuf:"varint,5,opt,name=streaming_supported,json=streamingSupported,proto3" json:"streaming_supported,omitempty"`
-	IntendedImage      *bootz.SoftwareImage   `protobuf:"bytes,6,opt,name=intended_image,json=intendedImage,proto3" json:"intended_image,omitempty"`
-	BootPasswordHash   string                 `protobuf:"bytes,7,opt,name=boot_password_hash,json=bootPasswordHash,proto3" json:"boot_password_hash,omitempty"`
-	BootConfig         *bootz.BootConfig      `protobuf:"bytes,8,opt,name=boot_config,json=bootConfig,proto3" json:"boot_config,omitempty"`
-	Credentials        *bootz.Credentials     `protobuf:"bytes,9,opt,name=credentials,proto3" json:"credentials,omitempty"`
-	Pathz              *pathz.UploadRequest   `protobuf:"bytes,10,opt,name=pathz,proto3" json:"pathz,omitempty"`
-	Authz              *authz.UploadRequest   `protobuf:"bytes,11,opt,name=authz,proto3" json:"authz,omitempty"`
-	CertzProfiles      *bootz.CertzProfiles   `protobuf:"bytes,12,opt,name=certz_profiles,json=certzProfiles,proto3" json:"certz_profiles,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	state                      protoimpl.MessageState `protogen:"open.v1"`
+	Manufacturer               string                 `protobuf:"bytes,1,opt,name=manufacturer,proto3" json:"manufacturer,omitempty"`
+	ControlCards               []*ControlCard         `protobuf:"bytes,2,rep,name=control_cards,json=controlCards,proto3" json:"control_cards,omitempty"`
+	Hostname                   string                 `protobuf:"bytes,3,opt,name=hostname,proto3" json:"hostname,omitempty"`
+	BootMode                   bootz.BootMode         `protobuf:"varint,4,opt,name=boot_mode,json=bootMode,proto3,enum=bootz.BootMode" json:"boot_mode,omitempty"`
+	StreamingSupported         bool                   `protobuf:"varint,5,opt,name=streaming_supported,json=streamingSupported,proto3" json:"streaming_supported,omitempty"`
+	IntendedImage              *bootz.SoftwareImage   `protobuf:"bytes,6,opt,name=intended_image,json=intendedImage,proto3" json:"intended_image,omitempty"`
+	BootPasswordHash           string                 `protobuf:"bytes,7,opt,name=boot_password_hash,json=bootPasswordHash,proto3" json:"boot_password_hash,omitempty"`
+	BootConfig                 *bootz.BootConfig      `protobuf:"bytes,8,opt,name=boot_config,json=bootConfig,proto3" json:"boot_config,omitempty"`
+	Credentials                *bootz.Credentials     `protobuf:"bytes,9,opt,name=credentials,proto3" json:"credentials,omitempty"`
+	Pathz                      *pathz.UploadRequest   `protobuf:"bytes,10,opt,name=pathz,proto3" json:"pathz,omitempty"`
+	Authz                      *authz.UploadRequest   `protobuf:"bytes,11,opt,name=authz,proto3" json:"authz,omitempty"`
+	CertzProfiles              *bootz.CertzProfiles   `protobuf:"bytes,12,opt,name=certz_profiles,json=certzProfiles,proto3" json:"certz_profiles,omitempty"`
+	SkipIdevidSerialValidation bool                   `protobuf:"varint,13,opt,name=skip_idevid_serial_validation,json=skipIdevidSerialValidation,proto3" json:"skip_idevid_serial_validation,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *Chassis) Reset() {
@@ -293,6 +294,13 @@ func (x *Chassis) GetCertzProfiles() *bootz.CertzProfiles {
 	return nil
 }
 
+func (x *Chassis) GetSkipIdevidSerialValidation() bool {
+	if x != nil {
+		return x.SkipIdevidSerialValidation
+	}
+	return false
+}
+
 type ControlCard struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	SerialNumber     string                 `protobuf:"bytes,1,opt,name=serial_number,json=serialNumber,proto3" json:"serial_number,omitempty"`
@@ -384,7 +392,7 @@ const file_github_com_openconfig_bootz_server_proto_config_proto_rawDesc = "" +
 	"\achassis\x18\x05 \x03(\v2\x0f.config.ChassisR\achassis\"3\n" +
 	"\vCertKeyPair\x12\x12\n" +
 	"\x04cert\x18\x01 \x01(\tR\x04cert\x12\x10\n" +
-	"\x03key\x18\x02 \x01(\tR\x03key\"\xdc\x04\n" +
+	"\x03key\x18\x02 \x01(\tR\x03key\"\x9f\x05\n" +
 	"\aChassis\x12\"\n" +
 	"\fmanufacturer\x18\x01 \x01(\tR\fmanufacturer\x128\n" +
 	"\rcontrol_cards\x18\x02 \x03(\v2\x13.config.ControlCardR\fcontrolCards\x12\x1a\n" +
@@ -399,7 +407,8 @@ const file_github_com_openconfig_bootz_server_proto_config_proto_rawDesc = "" +
 	"\x05pathz\x18\n" +
 	" \x01(\v2\x1c.gnsi.pathz.v1.UploadRequestR\x05pathz\x122\n" +
 	"\x05authz\x18\v \x01(\v2\x1c.gnsi.authz.v1.UploadRequestR\x05authz\x12;\n" +
-	"\x0ecertz_profiles\x18\f \x01(\v2\x14.bootz.CertzProfilesR\rcertzProfiles\"\xec\x01\n" +
+	"\x0ecertz_profiles\x18\f \x01(\v2\x14.bootz.CertzProfilesR\rcertzProfiles\x12A\n" +
+	"\x1dskip_idevid_serial_validation\x18\r \x01(\bR\x1askipIdevidSerialValidation\"\xec\x01\n" +
 	"\vControlCard\x12#\n" +
 	"\rserial_number\x18\x01 \x01(\tR\fserialNumber\x12+\n" +
 	"\x11ownership_voucher\x18\x02 \x01(\tR\x10ownershipVoucher\x12\x1d\n" +


### PR DESCRIPTION
This change enables skipping IDevId serial validation in the server emulator because some manufacturers may not have IDevId support.

This change also add unit tests for the chassis manager and fixes the client to dial the correct port.